### PR TITLE
공휴일 지정 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ function App() {
     removeStaff,
     updateAssignment,
     toggleLock,
+    toggleHoliday,
     setStartDate,
     setPreviousPeriodEnd,
     generateAutoSchedule,
@@ -212,6 +213,7 @@ function App() {
                     affectedCells={affectedCells}
                     onAssignmentChange={updateAssignment}
                     onToggleLock={toggleLock}
+                    onToggleHoliday={toggleHoliday}
                     onEditingCellChange={setEditingCell}
                     onHoverCellChange={setHoveredCell}
                   />

--- a/src/components/ScheduleGrid.tsx
+++ b/src/components/ScheduleGrid.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { addDays, parseISO, format } from 'date-fns';
 import type { Schedule, Staff, Violation, ShiftType, ShiftAssignment } from '@/types';
-import { formatDateKorean, isWeekend } from '@/utils/dateUtils';
+import { formatDateKorean, isWeekend, isHoliday } from '@/utils/dateUtils';
 import { DAY_NAMES } from '@/utils/dayUtils';
 import { countShiftsByType, countStaffByShiftPerDate } from '@/utils/shiftUtils';
 import { getCellKey, type ImpactReason } from '@/utils/impactCalculator';
@@ -15,6 +15,7 @@ interface ScheduleGridProps {
   affectedCells: Map<string, ImpactReason>;
   onAssignmentChange: (staffId: string, date: string, shift: ShiftType) => void;
   onToggleLock?: (staffId: string, date: string) => void;
+  onToggleHoliday?: (date: string) => void;
   onEditingCellChange?: (cell: { staffId: string; date: string } | null) => void;
   onHoverCellChange?: (cell: { staffId: string; date: string } | null) => void;
 }
@@ -26,9 +27,11 @@ export function ScheduleGrid({
   affectedCells,
   onAssignmentChange,
   onToggleLock,
+  onToggleHoliday,
   onEditingCellChange,
   onHoverCellChange,
 }: ScheduleGridProps) {
+  const holidays = schedule.holidays ?? [];
   // Generate 28 dates from schedule.startDate
   const dates = useMemo(() => {
     const result: { date: Date; dateString: string }[] = [];
@@ -123,18 +126,28 @@ export function ScheduleGrid({
             >
               직원
             </th>
-            {dates.map(({ date, dateString }) => (
-              <th
-                key={dateString}
-                scope="col"
-                className={cn(
-                  'p-2 border-b border-gray-200 text-center text-xs font-medium whitespace-nowrap',
-                  isWeekend(date) ? 'bg-slate-200 text-slate-700' : 'bg-gray-50 text-gray-600'
-                )}
-              >
-                {formatDateKorean(date)}
-              </th>
-            ))}
+            {dates.map(({ date, dateString }) => {
+              const isDateHoliday = isHoliday(date, holidays);
+              const isDateWeekend = isWeekend(date);
+              return (
+                <th
+                  key={dateString}
+                  scope="col"
+                  className={cn(
+                    'p-2 border-b border-gray-200 text-center text-xs font-medium whitespace-nowrap cursor-pointer select-none hover:opacity-80 transition-opacity',
+                    isDateHoliday
+                      ? 'bg-rose-200 text-rose-700'
+                      : isDateWeekend
+                        ? 'bg-slate-200 text-slate-700'
+                        : 'bg-gray-50 text-gray-600'
+                  )}
+                  onClick={() => onToggleHoliday?.(dateString)}
+                  title={isDateHoliday ? '클릭하여 공휴일 해제' : '클릭하여 공휴일 지정'}
+                >
+                  {formatDateKorean(date)}{isDateHoliday && '*'}
+                </th>
+              );
+            })}
             {/* Summary columns - sticky right */}
             <th
               scope="col"
@@ -188,12 +201,16 @@ export function ScheduleGrid({
                   const assignment = assignmentMap.get(key);
                   const cellViolations = violationMap.get(key) || [];
                   const affectReason = affectedCells.get(key);
+                  const isDateHoliday = isHoliday(date, holidays);
+                  const isDateWeekend = isWeekend(date);
                   return (
                     <td
                       key={dateString}
                       className={cn(
                         'p-1 border-b border-gray-200',
-                        isWeekend(date) && 'bg-slate-100',
+                        isDateHoliday
+                          ? 'bg-rose-50'
+                          : isDateWeekend && 'bg-slate-100',
                         isLastRow && 'border-b-0'
                       )}
                     >
@@ -264,12 +281,16 @@ export function ScheduleGrid({
             </td>
             {dates.map(({ date, dateString }) => {
               const counts = perDateCounts.get(dateString);
+              const isDateHoliday = isHoliday(date, holidays);
+              const isDateWeekend = isWeekend(date);
               return (
                 <td
                   key={dateString}
                   className={cn(
                     'p-2 border-t border-gray-200 text-center text-sm font-medium text-amber-600',
-                    isWeekend(date) && 'bg-amber-200/70'
+                    isDateHoliday
+                      ? 'bg-rose-100'
+                      : isDateWeekend && 'bg-amber-200/70'
                   )}
                 >
                   {counts?.D ?? 0}
@@ -288,12 +309,16 @@ export function ScheduleGrid({
             </td>
             {dates.map(({ date, dateString }) => {
               const counts = perDateCounts.get(dateString);
+              const isDateHoliday = isHoliday(date, holidays);
+              const isDateWeekend = isWeekend(date);
               return (
                 <td
                   key={dateString}
                   className={cn(
                     'p-2 text-center text-sm font-medium text-blue-600',
-                    isWeekend(date) && 'bg-blue-200/70'
+                    isDateHoliday
+                      ? 'bg-rose-100'
+                      : isDateWeekend && 'bg-blue-200/70'
                   )}
                 >
                   {counts?.E ?? 0}
@@ -312,12 +337,16 @@ export function ScheduleGrid({
             </td>
             {dates.map(({ date, dateString }) => {
               const counts = perDateCounts.get(dateString);
+              const isDateHoliday = isHoliday(date, holidays);
+              const isDateWeekend = isWeekend(date);
               return (
                 <td
                   key={dateString}
                   className={cn(
                     'p-2 text-center text-sm font-medium text-purple-600',
-                    isWeekend(date) && 'bg-purple-200/70'
+                    isDateHoliday
+                      ? 'bg-rose-100'
+                      : isDateWeekend && 'bg-purple-200/70'
                   )}
                 >
                   {counts?.N ?? 0}

--- a/src/constraints/staffing.ts
+++ b/src/constraints/staffing.ts
@@ -1,7 +1,8 @@
-import { parseISO, addDays, format, isWeekend } from 'date-fns';
+import { parseISO, addDays, format } from 'date-fns';
 import type { Violation } from '@/types';
 import type { Constraint, ConstraintContext } from './types';
 import { getSeverityFromConfig } from './types';
+import { isWeekendOrHoliday } from '@/utils/dateUtils';
 
 const SHIFT_TYPE_NAMES: Record<'D' | 'E' | 'N', string> = {
   D: '데이',
@@ -31,13 +32,14 @@ export const staffingConstraint: Constraint = {
 
     const startDate = parseISO(schedule.startDate);
     const periodDays = 28;
+    const holidays = schedule.holidays ?? [];
 
     for (let i = 0; i < periodDays; i++) {
       const currentDateObj = addDays(startDate, i);
       const currentDate = format(currentDateObj, 'yyyy-MM-dd');
-      const weekend = isWeekend(currentDateObj);
+      const isWeekendOrHolidayDate = isWeekendOrHoliday(currentDateObj, holidays);
 
-      const staffingReq = weekend ? config.weekendStaffing : config.weekdayStaffing;
+      const staffingReq = isWeekendOrHolidayDate ? config.weekendStaffing : config.weekdayStaffing;
 
       // Count staff per shift type for this date
       const shiftCounts: Record<'D' | 'E' | 'N', number> = { D: 0, E: 0, N: 0 };

--- a/src/constraints/weekendFairness.ts
+++ b/src/constraints/weekendFairness.ts
@@ -1,6 +1,7 @@
-import { parseISO, addDays, format, getDay } from 'date-fns';
+import { parseISO, addDays, format } from 'date-fns';
 import type { Violation, ShiftAssignment } from '@/types';
 import type { Constraint, ConstraintContext } from './types';
+import { isWeekendOrHoliday } from '@/utils/dateUtils';
 
 function getShiftForStaffOnDate(
   assignments: ShiftAssignment[],
@@ -11,11 +12,6 @@ function getShiftForStaffOnDate(
     (a) => a.staffId === staffId && a.date === date
   );
   return assignment?.shift ?? null;
-}
-
-function isWeekend(date: Date): boolean {
-  const day = getDay(date);
-  return day === 0 || day === 6; // Sunday or Saturday
 }
 
 export const weekendFairnessConstraint: Constraint = {
@@ -35,8 +31,9 @@ export const weekendFairnessConstraint: Constraint = {
 
     const startDate = parseISO(schedule.startDate);
     const periodDays = 28;
+    const holidays = schedule.holidays ?? [];
 
-    // Count weekend work days for each staff member
+    // Count weekend/holiday work days for each staff member
     const weekendWorkCounts: Map<string, number> = new Map();
 
     for (const staffMember of staff) {
@@ -46,7 +43,7 @@ export const weekendFairnessConstraint: Constraint = {
         const currentDate = addDays(startDate, i);
         const currentDateStr = format(currentDate, 'yyyy-MM-dd');
 
-        if (!isWeekend(currentDate)) {
+        if (!isWeekendOrHoliday(currentDate, holidays)) {
           continue;
         }
 

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -311,9 +311,25 @@ export function useSchedule() {
       startDate: date,
       // Clear assignments when period changes
       assignments: [],
+      // Clear holidays when period changes
+      holidays: [],
     }));
     setPreviousPeriodEnd([]);
   }, [setSchedule, setPreviousPeriodEnd]);
+
+  const toggleHoliday = useCallback((date: string) => {
+    setSchedule((prev) => {
+      const holidays = prev.holidays ?? [];
+      const isCurrentlyHoliday = holidays.includes(date);
+
+      return {
+        ...prev,
+        holidays: isCurrentlyHoliday
+          ? holidays.filter((h) => h !== date)
+          : [...holidays, date],
+      };
+    });
+  }, [setSchedule]);
 
   const clearSchedule = useCallback(() => {
     setSchedule((prev) => ({
@@ -353,6 +369,7 @@ export function useSchedule() {
         constraintSeverity: config.constraintSeverity,
         softConstraints: config.softConstraints,
       },
+      holidays: schedule.holidays,
     };
 
     try {
@@ -476,6 +493,7 @@ export function useSchedule() {
     // Schedule actions
     updateAssignment,
     toggleLock,
+    toggleHoliday,
     setStartDate,
     clearSchedule,
     setPreviousPeriodEnd,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -31,6 +31,7 @@ export interface GenerateRequest {
   };
   previousPeriodEnd?: ShiftAssignment[];
   lockedAssignments?: ShiftAssignment[];
+  holidays?: string[];
 }
 
 export interface GenerateResponse {
@@ -51,6 +52,7 @@ export interface FeasibilityCheckRequest {
     weekendStaffing: DailyStaffing;
     constraintSeverity?: ApiConstraintSeverity;
   };
+  holidays?: string[];
 }
 
 export interface FeasibilityCheckResponse {

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -15,6 +15,7 @@ export interface Schedule {
   startDate: string;
   assignments: ShiftAssignment[];
   staffJuhuDays?: Array<{ staffId: string; juhuDay: DayOfWeek }>;
+  holidays?: string[];
 }
 
 export interface PreviousPeriodData {

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -50,3 +50,18 @@ export function forEachDateInRange(
 export function isWeekend(date: Date): boolean {
   return dateFnsIsWeekend(date);
 }
+
+/**
+ * Check if a date is a holiday.
+ */
+export function isHoliday(date: Date, holidays: string[]): boolean {
+  const dateString = format(date, 'yyyy-MM-dd');
+  return holidays.includes(dateString);
+}
+
+/**
+ * Check if a date falls on a weekend or is a holiday.
+ */
+export function isWeekendOrHoliday(date: Date, holidays: string[] = []): boolean {
+  return dateFnsIsWeekend(date) || isHoliday(date, holidays);
+}


### PR DESCRIPTION
## Summary
- 날짜 헤더 클릭으로 공휴일 토글 기능 추가 (rose 색상으로 시각적 구분)
- 공휴일을 주말과 동일하게 인력배치(staffing) 및 주말공정성(weekendFairness) 제약조건에 반영
- Schedule 타입에 `holidays` 필드 추가, API 요청(generate/feasibility)에 holidays 전달

## Test plan
- [ ] 날짜 헤더 클릭으로 공휴일 토글 확인 (rose 배경색 적용/해제)
- [ ] 공휴일 지정 시 해당 날짜에 주말 인력배치 기준 적용되는지 확인
- [ ] 주말공정성 제약조건에서 공휴일 근무가 주말 근무로 카운트되는지 확인
- [ ] 기간 변경 시 공휴일 목록 초기화 확인
- [ ] 자동생성 API 요청에 holidays 필드 포함되는지 확인 (Network 탭)
- [ ] localStorage 저장/복원 시 holidays 필드 유지 확인
- [x] `npm run build` 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)