### PR TITLE
주차별 최소인원 설정 기능 추가

### DIFF
--- a/src/components/ConfigPanel.tsx
+++ b/src/components/ConfigPanel.tsx
@@ -104,141 +104,92 @@ export function ConfigPanel({ config, onConfigChange }: ConfigPanelProps) {
       </Card>
 
       <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">평일 최소인원</CardTitle>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle className="text-lg">주차별 최소인원</CardTitle>
+          <button
+            type="button"
+            onClick={() => {
+              updateConfig({
+                weeklyStaffing: Array.from({ length: 4 }, () =>
+                  structuredClone(config.weeklyStaffing[0])
+                ),
+              });
+            }}
+            className="text-xs px-3 py-1.5 rounded-md bg-gray-100 hover:bg-gray-200 text-gray-600 transition-colors"
+          >
+            1주차 기준 일괄 적용
+          </button>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            <div>
-              <Label htmlFor="weekday-day">데이 (D)</Label>
-              <Input
-                id="weekday-day"
-                type="number"
-                min={0}
-                value={config.weekdayStaffing.day.min}
-                onChange={(e) =>
-                  updateConfig({
-                    weekdayStaffing: {
-                      ...config.weekdayStaffing,
-                      day: {
-                        ...config.weekdayStaffing.day,
-                        min: Number(e.target.value),
-                      },
-                    },
-                  })
-                }
-              />
-            </div>
-            <div>
-              <Label htmlFor="weekday-evening">이브닝 (E)</Label>
-              <Input
-                id="weekday-evening"
-                type="number"
-                min={0}
-                value={config.weekdayStaffing.evening.min}
-                onChange={(e) =>
-                  updateConfig({
-                    weekdayStaffing: {
-                      ...config.weekdayStaffing,
-                      evening: {
-                        ...config.weekdayStaffing.evening,
-                        min: Number(e.target.value),
-                      },
-                    },
-                  })
-                }
-              />
-            </div>
-            <div>
-              <Label htmlFor="weekday-night">나이트 (N)</Label>
-              <Input
-                id="weekday-night"
-                type="number"
-                min={0}
-                value={config.weekdayStaffing.night.min}
-                onChange={(e) =>
-                  updateConfig({
-                    weekdayStaffing: {
-                      ...config.weekdayStaffing,
-                      night: {
-                        ...config.weekdayStaffing.night,
-                        min: Number(e.target.value),
-                      },
-                    },
-                  })
-                }
-              />
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">주말 최소인원</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            <div>
-              <Label htmlFor="weekend-day">데이 (D)</Label>
-              <Input
-                id="weekend-day"
-                type="number"
-                min={0}
-                value={config.weekendStaffing.day.min}
-                onChange={(e) =>
-                  updateConfig({
-                    weekendStaffing: {
-                      ...config.weekendStaffing,
-                      day: {
-                        ...config.weekendStaffing.day,
-                        min: Number(e.target.value),
-                      },
-                    },
-                  })
-                }
-              />
-            </div>
-            <div>
-              <Label htmlFor="weekend-evening">이브닝 (E)</Label>
-              <Input
-                id="weekend-evening"
-                type="number"
-                min={0}
-                value={config.weekendStaffing.evening.min}
-                onChange={(e) =>
-                  updateConfig({
-                    weekendStaffing: {
-                      ...config.weekendStaffing,
-                      evening: {
-                        ...config.weekendStaffing.evening,
-                        min: Number(e.target.value),
-                      },
-                    },
-                  })
-                }
-              />
-            </div>
-            <div>
-              <Label htmlFor="weekend-night">나이트 (N)</Label>
-              <Input
-                id="weekend-night"
-                type="number"
-                min={0}
-                value={config.weekendStaffing.night.min}
-                onChange={(e) =>
-                  updateConfig({
-                    weekendStaffing: {
-                      ...config.weekendStaffing,
-                      night: {
-                        ...config.weekendStaffing.night,
-                        min: Number(e.target.value),
-                      },
-                    },
-                  })
-                }
-              />
-            </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr>
+                  <th className="text-left py-2 pr-2 min-w-[3rem]" />
+                  {[1, 2, 3, 4].map((week) => (
+                    <th
+                      key={week}
+                      colSpan={3}
+                      className="text-center py-2 px-1 font-medium border-l border-gray-100 first:border-l-0"
+                    >
+                      {week}주차
+                    </th>
+                  ))}
+                </tr>
+                <tr>
+                  <th className="text-left py-1 pr-2" />
+                  {[0, 1, 2, 3].flatMap((week) =>
+                    ['D', 'E', 'N'].map((shift) => (
+                      <th
+                        key={`${week}-${shift}`}
+                        className="text-center py-1 px-1 text-xs text-muted-foreground font-normal"
+                      >
+                        {shift}
+                      </th>
+                    ))
+                  )}
+                </tr>
+              </thead>
+              <tbody>
+                {(['weekday', 'weekend'] as const).map((dayType) => (
+                  <tr key={dayType} className="border-t border-gray-100">
+                    <td className="py-2 pr-2 font-medium text-sm whitespace-nowrap">
+                      {dayType === 'weekday' ? '평일' : '주말'}
+                    </td>
+                    {config.weeklyStaffing.flatMap((weekConfig, weekIndex) =>
+                      (['day', 'evening', 'night'] as const).map((shiftKey) => (
+                        <td key={`${weekIndex}-${shiftKey}`} className="py-1 px-1">
+                          <Input
+                            type="number"
+                            min={0}
+                            className="w-14 h-8 text-center text-sm px-1"
+                            value={weekConfig[dayType][shiftKey].min}
+                            onChange={(e) => {
+                              const newWeeklyStaffing = config.weeklyStaffing.map(
+                                (w, i) =>
+                                  i === weekIndex
+                                    ? {
+                                        ...w,
+                                        [dayType]: {
+                                          ...w[dayType],
+                                          [shiftKey]: {
+                                            ...w[dayType][shiftKey],
+                                            min: Number(e.target.value),
+                                          },
+                                        },
+                                      }
+                                    : w
+                              );
+                              updateConfig({ weeklyStaffing: newWeeklyStaffing });
+                            }}
+                          />
+                        </td>
+                      ))
+                    )}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         </CardContent>
       </Card>

--- a/src/components/FeasibilityResult.tsx
+++ b/src/components/FeasibilityResult.tsx
@@ -180,8 +180,8 @@ export function FeasibilityResult({ result, completeness = 0, preCheckResult }: 
           {preCheckResult.analysis && (
             <div className="mt-3 text-xs text-red-600 flex flex-wrap gap-x-4 gap-y-1">
               <span>직원: {preCheckResult.analysis.staffCount}명</span>
-              <span>평일 최소: {preCheckResult.analysis.weekdayMinStaff}명</span>
-              <span>주말 최소: {preCheckResult.analysis.weekendMinStaff}명</span>
+              <span>필요: {preCheckResult.analysis.totalRequired} person-days</span>
+              <span>가용: {preCheckResult.analysis.totalAvailable} person-days</span>
               <span>주당 OFF: {preCheckResult.analysis.offDaysRequired}일</span>
             </div>
           )}

--- a/src/constraints/__tests__/consecutiveNight.test.ts
+++ b/src/constraints/__tests__/consecutiveNight.test.ts
@@ -21,16 +21,18 @@ function createTestContext(
     maxConsecutiveNights,
     monthlyNightsRequired: 7,
     weeklyWorkHours: 40,
-    weekdayStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
-    weekendStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
+    weeklyStaffing: Array.from({ length: 4 }, () => ({
+      weekday: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+      weekend: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+    })),
     enabledConstraints: {
       shiftOrder: true,
       nightOffDay: true,

--- a/src/constraints/__tests__/maxConsecutiveOff.test.ts
+++ b/src/constraints/__tests__/maxConsecutiveOff.test.ts
@@ -22,16 +22,18 @@ function createTestContext(
     maxConsecutiveNights: 4,
     monthlyNightsRequired: 7,
     weeklyWorkHours: 40,
-    weekdayStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
-    weekendStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
+    weeklyStaffing: Array.from({ length: 4 }, () => ({
+      weekday: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+      weekend: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+    })),
     enabledConstraints: {
       shiftOrder: true,
       nightOffDay: true,

--- a/src/constraints/__tests__/maxConsecutiveWork.test.ts
+++ b/src/constraints/__tests__/maxConsecutiveWork.test.ts
@@ -22,16 +22,18 @@ function createTestContext(
     maxConsecutiveNights: 4,
     monthlyNightsRequired: 7,
     weeklyWorkHours: 40,
-    weekdayStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
-    weekendStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
+    weeklyStaffing: Array.from({ length: 4 }, () => ({
+      weekday: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+      weekend: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+    })),
     enabledConstraints: {
       shiftOrder: true,
       nightOffDay: true,

--- a/src/constraints/__tests__/maxPeriodOff.test.ts
+++ b/src/constraints/__tests__/maxPeriodOff.test.ts
@@ -21,16 +21,18 @@ function createTestContext(
     maxConsecutiveNights: 4,
     monthlyNightsRequired: 7,
     weeklyWorkHours: 40,
-    weekdayStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
-    weekendStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
+    weeklyStaffing: Array.from({ length: 4 }, () => ({
+      weekday: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+      weekend: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+    })),
     enabledConstraints: {
       shiftOrder: true,
       nightOffDay: true,

--- a/src/constraints/__tests__/monthlyNight.test.ts
+++ b/src/constraints/__tests__/monthlyNight.test.ts
@@ -20,16 +20,18 @@ function createTestContext(
     maxConsecutiveNights: 4,
     monthlyNightsRequired,
     weeklyWorkHours: 40,
-    weekdayStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
-    weekendStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
+    weeklyStaffing: Array.from({ length: 4 }, () => ({
+      weekday: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+      weekend: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+    })),
     enabledConstraints: {
       shiftOrder: true,
       nightOffDay: true,

--- a/src/constraints/__tests__/nightOffDay.test.ts
+++ b/src/constraints/__tests__/nightOffDay.test.ts
@@ -20,16 +20,18 @@ function createTestContext(
     maxConsecutiveNights: 4,
     monthlyNightsRequired: 7,
     weeklyWorkHours: 40,
-    weekdayStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
-    weekendStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
+    weeklyStaffing: Array.from({ length: 4 }, () => ({
+      weekday: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+      weekend: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+    })),
     enabledConstraints: {
       shiftOrder: true,
       nightOffDay: true,

--- a/src/constraints/__tests__/shiftOrder.test.ts
+++ b/src/constraints/__tests__/shiftOrder.test.ts
@@ -20,16 +20,18 @@ function createTestContext(
     maxConsecutiveNights: 4,
     monthlyNightsRequired: 7,
     weeklyWorkHours: 40,
-    weekdayStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
-    weekendStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
+    weeklyStaffing: Array.from({ length: 4 }, () => ({
+      weekday: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+      weekend: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+    })),
     enabledConstraints: {
       shiftOrder: true,
       nightOffDay: true,

--- a/src/constraints/__tests__/staffing.test.ts
+++ b/src/constraints/__tests__/staffing.test.ts
@@ -25,16 +25,18 @@ function createTestContext(
     maxConsecutiveNights: 4,
     monthlyNightsRequired: 7,
     weeklyWorkHours: 40,
-    weekdayStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 2, max: 2 },
-      night: { min: 1, max: 2 },
-    },
-    weekendStaffing: {
-      day: { min: 2, max: 2 },
-      evening: { min: 2, max: 2 },
-      night: { min: 2, max: 2 },
-    },
+    weeklyStaffing: Array.from({ length: 4 }, () => ({
+      weekday: {
+        day: { min: 1, max: 2 },
+        evening: { min: 2, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+      weekend: {
+        day: { min: 2, max: 2 },
+        evening: { min: 2, max: 2 },
+        night: { min: 2, max: 2 },
+      },
+    })),
     enabledConstraints: {
       shiftOrder: true,
       nightOffDay: true,

--- a/src/constraints/__tests__/weeklyOff.test.ts
+++ b/src/constraints/__tests__/weeklyOff.test.ts
@@ -21,16 +21,18 @@ function createTestContext(
     maxConsecutiveNights: 4,
     monthlyNightsRequired: 7,
     weeklyWorkHours,
-    weekdayStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
-    weekendStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 1, max: 2 },
-      night: { min: 1, max: 2 },
-    },
+    weeklyStaffing: Array.from({ length: 4 }, () => ({
+      weekday: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+      weekend: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+    })),
     enabledConstraints: {
       shiftOrder: true,
       nightOffDay: true,

--- a/src/constraints/staffing.ts
+++ b/src/constraints/staffing.ts
@@ -36,8 +36,10 @@ export const staffingConstraint: Constraint = {
       const currentDateObj = addDays(startDate, i);
       const currentDate = format(currentDateObj, 'yyyy-MM-dd');
       const weekend = isWeekend(currentDateObj);
+      const weekIndex = Math.min(Math.floor(i / 7), config.weeklyStaffing.length - 1);
+      const weekStaffing = config.weeklyStaffing[weekIndex];
 
-      const staffingReq = weekend ? config.weekendStaffing : config.weekdayStaffing;
+      const staffingReq = weekend ? weekStaffing.weekend : weekStaffing.weekday;
 
       // Count staff per shift type for this date
       const shiftCounts: Record<'D' | 'E' | 'N', number> = { D: 0, E: 0, N: 0 };

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -30,7 +30,7 @@ const STORAGE_KEYS = {
 } as const;
 
 // Schema version: increment when localStorage structure changes
-const CURRENT_SCHEMA_VERSION = 2;
+const CURRENT_SCHEMA_VERSION = 3;
 
 /**
  * Check and migrate localStorage schema.
@@ -44,22 +44,38 @@ function migrateStorageIfNeeded(): boolean {
   const version = storedVersion ? parseInt(storedVersion, 10) : 1;
 
   if (version < CURRENT_SCHEMA_VERSION) {
-    // Clear staff and schedule data
-    localStorage.removeItem(STORAGE_KEYS.staff);
-    localStorage.removeItem(STORAGE_KEYS.schedule);
-    localStorage.removeItem(STORAGE_KEYS.previousPeriod);
+    // v1 → v2: Clear staff and schedule data (juhuDay removed from Staff)
+    if (version < 2) {
+      localStorage.removeItem(STORAGE_KEYS.staff);
+      localStorage.removeItem(STORAGE_KEYS.schedule);
+      localStorage.removeItem(STORAGE_KEYS.previousPeriod);
+    }
 
-    // Clean up juhu-related fields from config (v1 → v2 migration)
     const storedConfig = localStorage.getItem(STORAGE_KEYS.config);
     if (storedConfig) {
       try {
         const config = JSON.parse(storedConfig);
-        if (config.constraintSeverity) {
-          delete config.constraintSeverity.juhu;
+
+        // v1 → v2: Clean up juhu-related fields
+        if (version < 2) {
+          if (config.constraintSeverity) {
+            delete config.constraintSeverity.juhu;
+          }
+          if (config.enabledConstraints) {
+            delete config.enabledConstraints.juhu;
+          }
         }
-        if (config.enabledConstraints) {
-          delete config.enabledConstraints.juhu;
+
+        // v2 → v3: weekdayStaffing/weekendStaffing → weeklyStaffing
+        if (version < 3 && config.weekdayStaffing && config.weekendStaffing && !config.weeklyStaffing) {
+          config.weeklyStaffing = Array.from({ length: 4 }, () => ({
+            weekday: config.weekdayStaffing,
+            weekend: config.weekendStaffing,
+          }));
+          delete config.weekdayStaffing;
+          delete config.weekendStaffing;
         }
+
         localStorage.setItem(STORAGE_KEYS.config, JSON.stringify(config));
       } catch {
         // If parsing fails, remove config entirely
@@ -348,8 +364,7 @@ export function useSchedule() {
         maxConsecutiveNights: config.maxConsecutiveNights,
         monthlyNightsRequired: config.monthlyNightsRequired,
         weeklyWorkHours: config.weeklyWorkHours,
-        weekdayStaffing: config.weekdayStaffing,
-        weekendStaffing: config.weekendStaffing,
+        weeklyStaffing: config.weeklyStaffing,
         constraintSeverity: config.constraintSeverity,
         softConstraints: config.softConstraints,
       },

--- a/src/solver/feasibilityChecker.ts
+++ b/src/solver/feasibilityChecker.ts
@@ -88,38 +88,35 @@ export function validateConfigConsistency(
     return warnings;
   }
 
-  // Check if staffing requirements are achievable
-  const { weekdayStaffing, weekendStaffing } = config;
+  // Check if staffing requirements are achievable (per week)
+  const { weeklyStaffing } = config;
 
-  // Minimum total staff needed per day (sum of minimums for all shifts)
-  const minWeekdayTotal =
-    weekdayStaffing.day.min +
-    weekdayStaffing.evening.min +
-    weekdayStaffing.night.min;
-  const minWeekendTotal =
-    weekendStaffing.day.min +
-    weekendStaffing.evening.min +
-    weekendStaffing.night.min;
+  for (let week = 0; week < weeklyStaffing.length; week++) {
+    const { weekday, weekend } = weeklyStaffing[week];
+    const weekLabel = `${week + 1}주차`;
 
-  // Each staff member can only work one shift per day
-  if (minWeekdayTotal > staffCount) {
-    warnings.push(
-      `평일 최소 인원 합계(${minWeekdayTotal}명)가 총 직원 수(${staffCount}명)를 초과합니다.`
-    );
-  }
+    const minWeekdayTotal =
+      weekday.day.min + weekday.evening.min + weekday.night.min;
+    const minWeekendTotal =
+      weekend.day.min + weekend.evening.min + weekend.night.min;
 
-  if (minWeekendTotal > staffCount) {
-    warnings.push(
-      `주말 최소 인원 합계(${minWeekendTotal}명)가 총 직원 수(${staffCount}명)를 초과합니다.`
-    );
+    if (minWeekdayTotal > staffCount) {
+      warnings.push(
+        `${weekLabel} 평일 최소 인원 합계(${minWeekdayTotal}명)가 총 직원 수(${staffCount}명)를 초과합니다.`
+      );
+    }
+
+    if (minWeekendTotal > staffCount) {
+      warnings.push(
+        `${weekLabel} 주말 최소 인원 합계(${minWeekendTotal}명)가 총 직원 수(${staffCount}명)를 초과합니다.`
+      );
+    }
   }
 
   // Check if monthly night requirement is feasible
-  // 28 days * nightsPerDay should be distributable among staff
   const { monthlyNightsRequired, maxConsecutiveNights } = config;
   const minNightStaffPerDay = Math.min(
-    weekdayStaffing.night.min,
-    weekendStaffing.night.min
+    ...weeklyStaffing.flatMap(w => [w.weekday.night.min, w.weekend.night.min])
   );
 
   // Total night shifts needed over 28 days (minimum)
@@ -154,16 +151,18 @@ export function getDefaultConfig(): ConstraintConfig {
     maxConsecutiveNights: 4,
     monthlyNightsRequired: 7,
     weeklyWorkHours: 40,
-    weekdayStaffing: {
-      day: { min: 1, max: 2 },
-      evening: { min: 2, max: 2 },
-      night: { min: 1, max: 2 },
-    },
-    weekendStaffing: {
-      day: { min: 2, max: 2 },
-      evening: { min: 2, max: 2 },
-      night: { min: 2, max: 2 },
-    },
+    weeklyStaffing: Array.from({ length: 4 }, () => ({
+      weekday: {
+        day: { min: 1, max: 2 },
+        evening: { min: 2, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+      weekend: {
+        day: { min: 2, max: 2 },
+        evening: { min: 2, max: 2 },
+        night: { min: 2, max: 2 },
+      },
+    })),
     enabledConstraints: {
       shiftOrder: true,
       nightOffDay: true,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,4 +1,4 @@
-import type { ShiftAssignment, DailyStaffing, DayOfWeek, ConstraintSeverity, SoftConstraintConfig } from './index';
+import type { ShiftAssignment, DayOfWeek, ConstraintSeverity, SoftConstraintConfig, WeeklyStaffing } from './index';
 
 export type GenerationStatus = 'idle' | 'loading' | 'success' | 'error';
 
@@ -24,8 +24,7 @@ export interface GenerateRequest {
     maxConsecutiveNights: number;
     monthlyNightsRequired: number;
     weeklyWorkHours: number;
-    weekdayStaffing: DailyStaffing;
-    weekendStaffing: DailyStaffing;
+    weeklyStaffing: WeeklyStaffing[];
     constraintSeverity?: ApiConstraintSeverity;
     softConstraints?: SoftConstraintConfig;
   };
@@ -47,8 +46,7 @@ export interface FeasibilityCheckRequest {
     maxConsecutiveNights: number;
     monthlyNightsRequired: number;
     weeklyWorkHours: number;
-    weekdayStaffing: DailyStaffing;
-    weekendStaffing: DailyStaffing;
+    weeklyStaffing: WeeklyStaffing[];
     constraintSeverity?: ApiConstraintSeverity;
   };
 }
@@ -58,9 +56,9 @@ export interface FeasibilityCheckResponse {
   reasons: string[];
   analysis?: {
     staffCount: number;
-    weekdayMinStaff: number;
-    weekendMinStaff: number;
     offDaysRequired: number;
     weeklyWorkHours: number;
+    totalRequired: number;
+    totalAvailable: number;
   };
 }

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -30,6 +30,11 @@ export interface DailyStaffing {
   night: StaffingRequirement;
 }
 
+export interface WeeklyStaffing {
+  weekday: DailyStaffing;
+  weekend: DailyStaffing;
+}
+
 export type ConstraintSeverity = 'hard' | 'soft';
 
 // Soft Constraint Configuration Types
@@ -74,8 +79,7 @@ export interface ConstraintConfig {
   maxConsecutiveNights: number;
   monthlyNightsRequired: number;
   weeklyWorkHours: number;
-  weekdayStaffing: DailyStaffing;
-  weekendStaffing: DailyStaffing;
+  weeklyStaffing: WeeklyStaffing[];
   enabledConstraints: {
     shiftOrder: boolean;
     nightOffDay: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,7 @@ export type {
   FeasibilityResult,
   StaffingRequirement,
   DailyStaffing,
+  WeeklyStaffing,
   ConstraintConfig,
   ConstraintSeverity,
   SoftConstraintItemConfig,


### PR DESCRIPTION
## Summary
- 기존 평일/주말 단일 인력 설정을 4주차 개별 설정(weeklyStaffing[])으로 확장
- ConfigPanel의 2-Card UI를 매트릭스 테이블로 대체하여 24개 값을 한 화면에 표시
- 프론트엔드(타입, constraint, feasibility, 마이그레이션) + 백엔드(CP-SAT solver, feasibility check) 전체 스택 변경

## Changes
| 영역 | 변경 |
|------|------|
| 타입 | `WeeklyStaffing` 인터페이스 추가, `ConstraintConfig` 변경 |
| UI | 매트릭스 테이블 + "1주차 기준 일괄 적용" 버튼 |
| 마이그레이션 | localStorage v2→v3 (기존 설정 보존) |
| Constraint | 주차별 config 참조 (`Math.floor(dayIndex/7)`) |
| API | `GenerateRequest`, `FeasibilityCheckResponse` 필드 변경 |

> 백엔드 변경: jongwony/api `feat/weekly-staffing-config` 브랜치

## Test plan
- [ ] `npm test` 전체 통과 확인
- [ ] 로컬 dev 서버에서 매트릭스 테이블 UI 렌더링 확인
- [ ] 1주차 값 변경 후 "일괄 적용" 버튼으로 4주차 모두 동기화 확인
- [ ] 주차별 서로 다른 값 설정 후 auto-generate 정상 동작 확인
- [ ] 기존 localStorage 데이터로 v2→v3 마이그레이션 정상 확인
- [x] GitHub Pages 배포 후 production 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
