### PR TITLE
직원별 가능 근무 타입(D/E/N) 설정 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ function App() {
     showAllViolations,
     addStaff,
     removeStaff,
+    updateStaff,
     updateAssignment,
     toggleLock,
     setStartDate,
@@ -212,6 +213,7 @@ function App() {
                     affectedCells={affectedCells}
                     onAssignmentChange={updateAssignment}
                     onToggleLock={toggleLock}
+                    onUpdateStaff={updateStaff}
                     onEditingCellChange={setEditingCell}
                     onHoverCellChange={setHoveredCell}
                   />

--- a/src/components/EligibilityPopover.tsx
+++ b/src/components/EligibilityPopover.tsx
@@ -1,0 +1,70 @@
+import type { EligibleShift } from '@/types';
+import { ContextMenu } from './ContextMenu';
+import { cn } from '@/lib/utils';
+
+interface EligibilityPopoverProps {
+  position: { x: number; y: number };
+  staffName: string;
+  eligibleShifts: EligibleShift[];
+  onUpdate: (shifts: EligibleShift[]) => void;
+  onClose: () => void;
+}
+
+const CANONICAL_ORDER: EligibleShift[] = ['D', 'E', 'N'];
+
+const SHIFT_BUTTONS: { shift: EligibleShift; label: string; activeClass: string }[] = [
+  { shift: 'D', label: 'D', activeClass: 'bg-amber-100 text-amber-800 border-amber-300' },
+  { shift: 'E', label: 'E', activeClass: 'bg-blue-100 text-blue-800 border-blue-300' },
+  { shift: 'N', label: 'N', activeClass: 'bg-indigo-100 text-indigo-800 border-indigo-300' },
+];
+
+export function EligibilityPopover({
+  position,
+  staffName,
+  eligibleShifts,
+  onUpdate,
+  onClose,
+}: EligibilityPopoverProps) {
+  const handleToggle = (shift: EligibleShift) => {
+    const isActive = eligibleShifts.includes(shift);
+    if (isActive && eligibleShifts.length <= 1) return; // min 1 required
+    const next = isActive
+      ? eligibleShifts.filter((s) => s !== shift)
+      : [...eligibleShifts, shift].sort(
+          (a, b) => CANONICAL_ORDER.indexOf(a) - CANONICAL_ORDER.indexOf(b)
+        );
+    onUpdate(next);
+  };
+
+  return (
+    <ContextMenu position={position} onClose={onClose}>
+      <div className="px-3 py-2 text-xs font-medium text-gray-500 border-b border-gray-100">
+        {staffName} - 가능 근무
+      </div>
+      <div className="flex gap-1.5 px-3 py-2">
+        {SHIFT_BUTTONS.map(({ shift, label, activeClass }) => {
+          const isActive = eligibleShifts.includes(shift);
+          const isLastActive = isActive && eligibleShifts.length <= 1;
+          return (
+            <button
+              key={shift}
+              type="button"
+              onClick={() => handleToggle(shift)}
+              disabled={isLastActive}
+              title={isLastActive ? '최소 1개 근무 유형이 필요합니다' : undefined}
+              className={cn(
+                'w-10 h-8 rounded border text-sm font-semibold transition-colors',
+                isActive
+                  ? activeClass
+                  : 'bg-gray-50 text-gray-300 border-gray-200 hover:bg-gray-100',
+                isLastActive && 'cursor-not-allowed opacity-60'
+              )}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+    </ContextMenu>
+  );
+}

--- a/src/components/ScheduleGrid.tsx
+++ b/src/components/ScheduleGrid.tsx
@@ -1,11 +1,13 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { addDays, parseISO, format } from 'date-fns';
-import type { Schedule, Staff, Violation, ShiftType, ShiftAssignment } from '@/types';
+import type { Schedule, Staff, Violation, ShiftType, ShiftAssignment, EligibleShift } from '@/types';
 import { formatDateKorean, isWeekend } from '@/utils/dateUtils';
 import { DAY_NAMES } from '@/utils/dayUtils';
 import { countShiftsByType, countStaffByShiftPerDate } from '@/utils/shiftUtils';
+import { getEligibleShifts } from '@/utils/staffUtils';
 import { getCellKey, type ImpactReason } from '@/utils/impactCalculator';
 import { ShiftCell } from './ShiftCell';
+import { EligibilityPopover } from './EligibilityPopover';
 import { cn } from '@/lib/utils';
 
 interface ScheduleGridProps {
@@ -15,6 +17,7 @@ interface ScheduleGridProps {
   affectedCells: Map<string, ImpactReason>;
   onAssignmentChange: (staffId: string, date: string, shift: ShiftType) => void;
   onToggleLock?: (staffId: string, date: string) => void;
+  onUpdateStaff?: (staffId: string, updates: { eligibleShifts: EligibleShift[] }) => void;
   onEditingCellChange?: (cell: { staffId: string; date: string } | null) => void;
   onHoverCellChange?: (cell: { staffId: string; date: string } | null) => void;
 }
@@ -26,9 +29,14 @@ export function ScheduleGrid({
   affectedCells,
   onAssignmentChange,
   onToggleLock,
+  onUpdateStaff,
   onEditingCellChange,
   onHoverCellChange,
 }: ScheduleGridProps) {
+  const [eligibilityPopover, setEligibilityPopover] = useState<{
+    staffId: string;
+    position: { x: number; y: number };
+  } | null>(null);
   // Generate 28 dates from schedule.startDate
   const dates = useMemo(() => {
     const result: { date: Date; dateString: string }[] = [];
@@ -170,17 +178,36 @@ export function ScheduleGrid({
               <tr key={staffMember.id} className="hover:bg-gray-50/50 transition-colors">
                 <td
                   className={cn(
-                    'sticky left-0 z-10 bg-white p-2 border-b border-r border-gray-200 text-sm font-medium min-w-[100px]',
+                    'sticky left-0 z-10 bg-white p-2 border-b border-r border-gray-200 text-sm font-medium min-w-[100px] cursor-pointer select-none hover:bg-gray-50',
                     isLastRow && 'border-b-0'
                   )}
+                  onClick={(e) => {
+                    setEligibilityPopover({
+                      staffId: staffMember.id,
+                      position: { x: e.clientX, y: e.clientY },
+                    });
+                  }}
+                  title="클릭하여 가능 근무 설정"
                 >
                   {(() => {
                     const juhuDay = schedule.staffJuhuDays?.find(
                       (j) => j.staffId === staffMember.id
                     )?.juhuDay;
-                    return juhuDay !== undefined
+                    const eligible = getEligibleShifts(staffMember);
+                    const isRestricted = eligible.length < 3;
+                    const nameText = juhuDay !== undefined
                       ? `${staffMember.name} (${DAY_NAMES[juhuDay]})`
                       : staffMember.name;
+                    return (
+                      <>
+                        {nameText}
+                        {isRestricted && (
+                          <span className="ml-1 text-xs text-gray-400">
+                            {eligible.join('')}
+                          </span>
+                        )}
+                      </>
+                    );
                   })()}
                 </td>
                 {dates.map(({ date, dateString }) => {
@@ -203,6 +230,7 @@ export function ScheduleGrid({
                         isAffected={affectReason !== undefined}
                         affectReason={affectReason}
                         isLocked={assignment?.isLocked ?? false}
+                        eligibleShifts={staffMember.eligibleShifts}
                         onChange={(shift) =>
                           onAssignmentChange(staffMember.id, dateString, shift)
                         }
@@ -339,6 +367,23 @@ export function ScheduleGrid({
       </div>
       {/* Scroll indicator - only on mobile */}
       <div className="absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-white to-transparent pointer-events-none sm:hidden" />
+
+      {/* Eligibility popover */}
+      {eligibilityPopover && (() => {
+        const popoverStaff = staff.find((s) => s.id === eligibilityPopover.staffId);
+        if (!popoverStaff) return null;
+        return (
+          <EligibilityPopover
+            position={eligibilityPopover.position}
+            staffName={popoverStaff.name}
+            eligibleShifts={getEligibleShifts(popoverStaff)}
+            onUpdate={(shifts) =>
+              onUpdateStaff?.(popoverStaff.id, { eligibleShifts: shifts })
+            }
+            onClose={() => setEligibilityPopover(null)}
+          />
+        );
+      })()}
     </div>
   );
 }

--- a/src/components/ShiftCell.tsx
+++ b/src/components/ShiftCell.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
-import type { ShiftType, Violation } from '@/types';
+import type { ShiftType, EligibleShift, Violation } from '@/types';
 import type { ImpactReason } from '@/utils/impactCalculator';
 import { cn } from '@/lib/utils';
 import { useLongPress } from '@/hooks/useLongPress';
@@ -12,6 +12,7 @@ interface ShiftCellProps {
   isAffected?: boolean;
   affectReason?: ImpactReason;
   isLocked?: boolean;
+  eligibleShifts?: EligibleShift[];
   onChange: (shift: ShiftType) => void;
   onToggleLock?: () => void;
   onFocus?: () => void;
@@ -32,7 +33,7 @@ const SHIFT_CONFIG: Record<ShiftType, { bg: string; hover: string; text: string;
   OFF: { bg: 'bg-slate-100', hover: 'hover:bg-slate-200', text: 'text-slate-600', label: '휴무' },
 };
 
-const SHIFT_CYCLE: (ShiftType | null)[] = [null, 'D', 'E', 'N', 'OFF'];
+const ALL_ELIGIBLE: EligibleShift[] = ['D', 'E', 'N'];
 
 export function ShiftCell({
   shift,
@@ -40,6 +41,7 @@ export function ShiftCell({
   isAffected,
   affectReason,
   isLocked,
+  eligibleShifts = ALL_ELIGIBLE,
   onChange,
   onToggleLock,
   onFocus,
@@ -56,20 +58,17 @@ export function ShiftCell({
   const violationMessages = violations.map((v) => v.message).join('\n');
   const impactStyle = affectReason ? IMPACT_STYLES[affectReason] : null;
 
+  // Build dynamic cycle from eligible shifts: [eligible..., 'OFF']
+  const cycle: ShiftType[] = [...eligibleShifts, 'OFF'];
+
   const handleClick = () => {
     if (isLocked) {
       toast.info('셀이 고정되어 있습니다. 우클릭으로 해제하세요.');
       return;
     }
-    const currentIndex = SHIFT_CYCLE.indexOf(shift);
-    const nextIndex = (currentIndex + 1) % SHIFT_CYCLE.length;
-    const nextShift = SHIFT_CYCLE[nextIndex];
-    if (nextShift !== null) {
-      onChange(nextShift);
-    } else {
-      // Skip null, go to D
-      onChange('D');
-    }
+    const currentIndex = shift !== null ? cycle.indexOf(shift) : -1;
+    const nextIndex = (currentIndex + 1) % cycle.length;
+    onChange(cycle[nextIndex]);
   };
 
   const handleContextMenu = (e: React.MouseEvent) => {

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/types';
 import { checkFeasibility, getDefaultConfig } from '@/solver/feasibilityChecker';
 import { calculateScheduleCompleteness } from '@/utils/shiftUtils';
+import { getEligibleShifts } from '@/utils/staffUtils';
 import {
   calculateCellImpact,
   buildImpactMap,
@@ -258,7 +259,7 @@ export function useSchedule() {
   }, [setStaff, setSchedule, setPreviousPeriodEnd]);
 
   const updateStaff = useCallback(
-    (staffId: string, updates: Partial<Pick<Staff, 'name'>>) => {
+    (staffId: string, updates: Partial<Pick<Staff, 'name' | 'eligibleShifts'>>) => {
       setStaff((prev) =>
         prev.map((s) => (s.id === staffId ? { ...s, ...updates } : s))
       );
@@ -358,7 +359,7 @@ export function useSchedule() {
     const lockedAssignments = schedule.assignments.filter((a) => a.isLocked);
 
     const requestPayload = {
-      staff: staff.map((s) => ({ id: s.id, name: s.name })),
+      staff: staff.map((s) => ({ id: s.id, name: s.name, eligibleShifts: getEligibleShifts(s) })),
       startDate: schedule.startDate,
       constraints: {
         maxConsecutiveNights: config.maxConsecutiveNights,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -18,7 +18,7 @@ export interface ApiConstraintSeverity {
 }
 
 export interface GenerateRequest {
-  staff: Array<{ id: string; name: string }>;
+  staff: Array<{ id: string; name: string; eligibleShifts?: ('D' | 'E' | 'N')[] }>;
   startDate: string;
   constraints: {
     maxConsecutiveNights: number;
@@ -40,7 +40,7 @@ export interface GenerateResponse {
 }
 
 export interface FeasibilityCheckRequest {
-  staff: Array<{ id: string; name: string }>;
+  staff: Array<{ id: string; name: string; eligibleShifts?: ('D' | 'E' | 'N')[] }>;
   startDate: string;
   constraints: {
     maxConsecutiveNights: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type { DayOfWeek, Staff } from './staff';
+export type { DayOfWeek, EligibleShift, Staff } from './staff';
 export type {
   ShiftType,
   ShiftAssignment,

--- a/src/types/staff.ts
+++ b/src/types/staff.ts
@@ -1,6 +1,9 @@
 export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
+export type EligibleShift = 'D' | 'E' | 'N';
+
 export interface Staff {
   id: string;
   name: string;
+  eligibleShifts?: EligibleShift[];
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,3 +12,4 @@ export {
   type CellImpact,
   type ImpactReason,
 } from './impactCalculator';
+export { getEligibleShifts, isShiftEligible } from './staffUtils';

--- a/src/utils/staffUtils.ts
+++ b/src/utils/staffUtils.ts
@@ -1,0 +1,14 @@
+import type { EligibleShift, Staff, ShiftType } from '@/types';
+
+const ALL_SHIFTS: EligibleShift[] = ['D', 'E', 'N'];
+
+/** Returns the eligible work shifts for a staff member, defaulting to all if unset. */
+export function getEligibleShifts(staff: Staff): EligibleShift[] {
+  return staff.eligibleShifts ?? ALL_SHIFTS;
+}
+
+/** Checks if a shift type is eligible for a staff member. OFF is always eligible. */
+export function isShiftEligible(staff: Staff, shift: ShiftType): boolean {
+  if (shift === 'OFF') return true;
+  return getEligibleShifts(staff).includes(shift as EligibleShift);
+}


### PR DESCRIPTION
## 요약

직원별 가능 근무 타입(D/E/N) 설정 기능 추가

- 스케줄 그리드에서 직원 이름 클릭 시 D/E/N 토글 팝오버 표시
- 수동 편집 시 불가능한 근무 자동 건너뛰기 (ShiftCell 사이클 필터링)
- 백엔드 solver에 eligibility 하드 제약 추가 (불가능한 근무 BoolVar = 0)
- feasibility 사전 검증에 근무별 가능 인원 확인 추가
- OFF는 항상 가능, 최소 1개 근무 타입 필수

## 변경 파일

**새 파일**: `EligibilityPopover.tsx`, `staffUtils.ts`
**프론트엔드**: Staff 타입, API 타입, ShiftCell, ScheduleGrid, useSchedule, App
**백엔드**: `schedule_generator.py` (HARD CONSTRAINT 0.5 + feasibility check)

## 테스트 계획

- [ ] 직원 이름 클릭 시 D/E/N 토글 팝오버가 올바르게 표시되는지 확인
- [ ] 토글 후 셀 클릭 사이클이 가능한 근무만 순환하는지 확인
- [ ] 마지막 남은 근무 타입의 비활성화가 차단되는지 확인
- [ ] 자동 생성 시 불가능한 근무가 배정되지 않는지 확인
- [ ] `npm run build` 빌드 성공 확인
- [ ] `npm test` 기존 테스트 전체 통과 확인
- [ ] 기존 localStorage 데이터(eligibleShifts 없음)에서 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
