### PR TITLE
직원별 근무 적격성 리뷰 결과 반영: 상태 일관성 + 접근성 개선

### DIFF
--- a/src/components/EligibilityPopover.tsx
+++ b/src/components/EligibilityPopover.tsx
@@ -51,6 +51,7 @@ export function EligibilityPopover({
               type="button"
               onClick={() => handleToggle(shift)}
               disabled={isLastActive}
+              aria-pressed={isActive}
               title={isLastActive ? '최소 1개 근무 유형이 필요합니다' : undefined}
               className={cn(
                 'w-10 h-8 rounded border text-sm font-semibold transition-colors',

--- a/src/components/ScheduleGrid.tsx
+++ b/src/components/ScheduleGrid.tsx
@@ -181,11 +181,26 @@ export function ScheduleGrid({
                     'sticky left-0 z-10 bg-white p-2 border-b border-r border-gray-200 text-sm font-medium min-w-[100px] cursor-pointer select-none hover:bg-gray-50',
                     isLastRow && 'border-b-0'
                   )}
+                  role="button"
+                  tabIndex={0}
+                  aria-haspopup="dialog"
                   onClick={(e) => {
                     setEligibilityPopover({
                       staffId: staffMember.id,
                       position: { x: e.clientX, y: e.clientY },
                     });
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      setEligibilityPopover({
+                        staffId: staffMember.id,
+                        position: {
+                          x: e.currentTarget.getBoundingClientRect().left,
+                          y: e.currentTarget.getBoundingClientRect().bottom,
+                        },
+                      });
+                    }
                   }}
                   title="클릭하여 가능 근무 설정"
                 >
@@ -230,7 +245,7 @@ export function ScheduleGrid({
                         isAffected={affectReason !== undefined}
                         affectReason={affectReason}
                         isLocked={assignment?.isLocked ?? false}
-                        eligibleShifts={staffMember.eligibleShifts}
+                        eligibleShifts={getEligibleShifts(staffMember)}
                         onChange={(shift) =>
                           onAssignmentChange(staffMember.id, dateString, shift)
                         }

--- a/src/components/ShiftCell.tsx
+++ b/src/components/ShiftCell.tsx
@@ -61,6 +61,8 @@ export function ShiftCell({
   // Build dynamic cycle from eligible shifts: [eligible..., 'OFF']
   const cycle: ShiftType[] = [...eligibleShifts, 'OFF'];
 
+  const isIneligible = shift !== null && shift !== 'OFF' && !eligibleShifts.includes(shift as EligibleShift);
+
   const handleClick = () => {
     if (isLocked) {
       toast.info('셀이 고정되어 있습니다. 우클릭으로 해제하세요.');
@@ -152,6 +154,8 @@ export function ShiftCell({
           !hasError && !hasWarning && !isAffected && !isLocked && 'border-gray-200 hover:border-gray-300',
           // Locked state
           isLocked && !hasError && !hasWarning && 'ring-2 ring-green-500 border-green-400',
+          // Ineligible assignment indicator
+          isIneligible && 'ring-2 ring-red-300 ring-inset border-dashed',
           // Pressing feedback (for long-press)
           isPressing && 'scale-95 opacity-70'
         )}

--- a/src/constraints/monthlyNight.ts
+++ b/src/constraints/monthlyNight.ts
@@ -1,5 +1,6 @@
 import type { Violation } from '@/types';
 import { countShiftsByType } from '@/utils/shiftUtils';
+import { getEligibleShifts } from '@/utils/staffUtils';
 import type { Constraint, ConstraintContext } from './types';
 import { getSeverityFromConfig } from './types';
 
@@ -17,6 +18,7 @@ export const monthlyNightConstraint: Constraint = {
     const required = config.monthlyNightsRequired;
 
     for (const staffMember of staff) {
+      if (!getEligibleShifts(staffMember).includes('N')) continue;
       const counts = countShiftsByType(schedule.assignments, staffMember.id);
       const nightCount = counts.N;
 

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -263,8 +263,21 @@ export function useSchedule() {
       setStaff((prev) =>
         prev.map((s) => (s.id === staffId ? { ...s, ...updates } : s))
       );
+
+      // Remove assignments that are no longer eligible after eligibility change
+      if (updates.eligibleShifts) {
+        const newEligible = updates.eligibleShifts;
+        setSchedule((prev) => ({
+          ...prev,
+          assignments: prev.assignments.filter((a) => {
+            if (a.staffId !== staffId) return true;
+            if (a.shift === 'OFF') return true;
+            return newEligible.includes(a.shift as typeof newEligible[number]);
+          }),
+        }));
+      }
     },
-    [setStaff]
+    [setStaff, setSchedule]
   );
 
   // ==================== Schedule Actions ====================

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,4 +1,5 @@
 import type { ShiftAssignment, DayOfWeek, ConstraintSeverity, SoftConstraintConfig, WeeklyStaffing } from './index';
+import type { EligibleShift } from './staff';
 
 export type GenerationStatus = 'idle' | 'loading' | 'success' | 'error';
 
@@ -18,7 +19,7 @@ export interface ApiConstraintSeverity {
 }
 
 export interface GenerateRequest {
-  staff: Array<{ id: string; name: string; eligibleShifts?: ('D' | 'E' | 'N')[] }>;
+  staff: Array<{ id: string; name: string; eligibleShifts?: EligibleShift[] }>;
   startDate: string;
   constraints: {
     maxConsecutiveNights: number;
@@ -40,7 +41,7 @@ export interface GenerateResponse {
 }
 
 export interface FeasibilityCheckRequest {
-  staff: Array<{ id: string; name: string; eligibleShifts?: ('D' | 'E' | 'N')[] }>;
+  staff: Array<{ id: string; name: string; eligibleShifts?: EligibleShift[] }>;
   startDate: string;
   constraints: {
     maxConsecutiveNights: number;


### PR DESCRIPTION
## Summary
- Cross-model review (Claude + Codex) 결과 발견된 상태 일관성, 접근성, 타입 안전성 이슈 수정
- 프론트엔드 constraint의 eligibility 맹점 해소 (monthlyNight)
- eligibility 변경 시 기존 비적격 배정 자동 정리

## Changes
| 우선순위 | 파일 | 변경 내용 |
|---------|------|----------|
| P0 | `monthlyNight.ts` | N-비적격 직원 야간 근무 검증 제외 |
| P0 | `useSchedule.ts` | eligibility 변경 시 비적격 배정 자동 제거 |
| P1 | `ScheduleGrid.tsx` | Staff name cell a11y (role, tabIndex, keyboard) |
| P2 | `ShiftCell.tsx` | 비적격 시프트 시각적 경고 (red ring) |
| P2 | `api.ts` | 인라인 타입 → `EligibleShift` 참조 통일 |
| P3 | `EligibilityPopover.tsx` | 토글 버튼 `aria-pressed` 추가 |

## Test plan
- [x] `npx vitest run src/constraints/__tests__/monthlyNight.test.ts` — 야간 constraint 테스트 통과 확인
- [x] N-비적격 직원 설정 후 monthlyNight 위반 표시 안 됨 확인
- [x] eligibility 변경 시 기존 비적격 배정이 자동 제거되는지 확인
- [x] locked 배정도 비적격 시 함께 제거되는지 확인
- [x] Staff name cell에서 Tab → Enter/Space로 팝오버 열기 확인
- [x] 비적격 시프트 배정 셀에 빨간 ring 표시 확인
- [x] 스크린리더로 EligibilityPopover 토글 상태 인식 확인
- [x] `npx tsc --noEmit` 타입 체크 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
