### PR TITLE
셀 단위 근무 배제(❌) 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,8 @@ function App() {
     updateStaff,
     updateAssignment,
     toggleLock,
+    toggleExclusion,
+    resetCell,
     setStartDate,
     setPreviousPeriodEnd,
     generateAutoSchedule,
@@ -213,6 +215,8 @@ function App() {
                     affectedCells={affectedCells}
                     onAssignmentChange={updateAssignment}
                     onToggleLock={toggleLock}
+                    onToggleExclusion={toggleExclusion}
+                    onResetCell={resetCell}
                     onUpdateStaff={updateStaff}
                     onEditingCellChange={setEditingCell}
                     onHoverCellChange={setHoveredCell}

--- a/src/components/ScheduleGrid.tsx
+++ b/src/components/ScheduleGrid.tsx
@@ -17,6 +17,8 @@ interface ScheduleGridProps {
   affectedCells: Map<string, ImpactReason>;
   onAssignmentChange: (staffId: string, date: string, shift: ShiftType) => void;
   onToggleLock?: (staffId: string, date: string) => void;
+  onToggleExclusion?: (staffId: string, date: string, shift: ShiftType) => void;
+  onResetCell?: (staffId: string, date: string) => void;
   onUpdateStaff?: (staffId: string, updates: { eligibleShifts: EligibleShift[] }) => void;
   onEditingCellChange?: (cell: { staffId: string; date: string } | null) => void;
   onHoverCellChange?: (cell: { staffId: string; date: string } | null) => void;
@@ -29,6 +31,8 @@ export function ScheduleGrid({
   affectedCells,
   onAssignmentChange,
   onToggleLock,
+  onToggleExclusion,
+  onResetCell,
   onUpdateStaff,
   onEditingCellChange,
   onHoverCellChange,
@@ -246,10 +250,15 @@ export function ScheduleGrid({
                         affectReason={affectReason}
                         isLocked={assignment?.isLocked ?? false}
                         eligibleShifts={getEligibleShifts(staffMember)}
+                        excludedShifts={schedule.cellExclusions?.[key] ?? []}
                         onChange={(shift) =>
                           onAssignmentChange(staffMember.id, dateString, shift)
                         }
                         onToggleLock={() => onToggleLock?.(staffMember.id, dateString)}
+                        onToggleExclusion={(shift) =>
+                          onToggleExclusion?.(staffMember.id, dateString, shift)
+                        }
+                        onResetCell={() => onResetCell?.(staffMember.id, dateString)}
                         onFocus={() =>
                           onEditingCellChange?.({ staffId: staffMember.id, date: dateString })
                         }

--- a/src/components/ShiftCell.tsx
+++ b/src/components/ShiftCell.tsx
@@ -13,8 +13,11 @@ interface ShiftCellProps {
   affectReason?: ImpactReason;
   isLocked?: boolean;
   eligibleShifts?: EligibleShift[];
+  excludedShifts?: ShiftType[];
   onChange: (shift: ShiftType) => void;
   onToggleLock?: () => void;
+  onToggleExclusion?: (shift: ShiftType) => void;
+  onResetCell?: () => void;
   onFocus?: () => void;
   onBlur?: () => void;
   onMouseEnter?: () => void;
@@ -34,6 +37,14 @@ const SHIFT_CONFIG: Record<ShiftType, { bg: string; hover: string; text: string;
 };
 
 const ALL_ELIGIBLE: EligibleShift[] = ['D', 'E', 'N'];
+const EMPTY_EXCLUSIONS: ShiftType[] = [];
+
+const EXCLUSION_BUTTON_STYLES: Record<ShiftType, string> = {
+  D: 'bg-amber-100 text-amber-800 border-amber-300',
+  E: 'bg-blue-100 text-blue-800 border-blue-300',
+  N: 'bg-indigo-100 text-indigo-800 border-indigo-300',
+  OFF: 'bg-slate-100 text-slate-600 border-slate-300',
+};
 
 export function ShiftCell({
   shift,
@@ -42,8 +53,11 @@ export function ShiftCell({
   affectReason,
   isLocked,
   eligibleShifts = ALL_ELIGIBLE,
+  excludedShifts = EMPTY_EXCLUSIONS,
   onChange,
   onToggleLock,
+  onToggleExclusion,
+  onResetCell,
   onFocus,
   onBlur,
   onMouseEnter,
@@ -57,9 +71,20 @@ export function ShiftCell({
   const hasWarning = violations.some((v) => v.severity === 'warning');
   const violationMessages = violations.map((v) => v.message).join('\n');
   const impactStyle = affectReason ? IMPACT_STYLES[affectReason] : null;
+  const hasExclusions = excludedShifts.length > 0;
 
-  // Build dynamic cycle from eligible shifts: [eligible..., 'OFF']
-  const cycle: ShiftType[] = [...eligibleShifts, 'OFF'];
+  // Build dynamic cycle: eligible shifts minus excluded, plus OFF if not excluded
+  const cycle: ShiftType[] = [
+    ...eligibleShifts.filter((s) => !excludedShifts.includes(s)),
+    ...(!excludedShifts.includes('OFF') ? ['OFF' as ShiftType] : []),
+  ];
+
+  // Available shifts for exclusion toggles: eligible + OFF
+  const availableForExclusion: ShiftType[] = [...eligibleShifts, 'OFF'];
+  const maxExclusions = Math.min(2, availableForExclusion.length - 2);
+
+  // Show exclusion section when cell has assignment or existing exclusions
+  const showExclusionSection = !isLocked && (shift !== null || hasExclusions) && maxExclusions > 0;
 
   const isIneligible = shift !== null && shift !== 'OFF' && !eligibleShifts.includes(shift as EligibleShift);
 
@@ -68,6 +93,7 @@ export function ShiftCell({
       toast.info('셀이 고정되어 있습니다. 우클릭으로 해제하세요.');
       return;
     }
+    if (cycle.length === 0) return;
     const currentIndex = shift !== null ? cycle.indexOf(shift) : -1;
     const nextIndex = (currentIndex + 1) % cycle.length;
     onChange(cycle[nextIndex]);
@@ -86,7 +112,7 @@ export function ShiftCell({
 
   const handleReset = () => {
     if (!isLocked) {
-      onChange('OFF');
+      onResetCell?.();
     }
     setShowContextMenu(false);
   };
@@ -109,11 +135,14 @@ export function ShiftCell({
 
   const config = shift ? SHIFT_CONFIG[shift] : null;
   const ariaLabel = config
-    ? `${config.label} (${shift})${violations.length > 0 ? `, ${violations.length}개 위반` : ''}${isAffected && impactStyle ? `, ${impactStyle.label}` : ''}`
-    : '근무 미배정, 클릭하여 배정';
+    ? `${config.label} (${shift})${violations.length > 0 ? `, ${violations.length}개 위반` : ''}${isAffected && impactStyle ? `, ${impactStyle.label}` : ''}${hasExclusions ? `, ${excludedShifts.join(',')} 배제` : ''}`
+    : `근무 미배정${hasExclusions ? `, ${excludedShifts.join(',')} 배제` : ''}, 클릭하여 배정`;
 
   // Build title with all relevant info
   const titleParts: string[] = [];
+  if (hasExclusions) {
+    titleParts.push(`배제: ${excludedShifts.join(', ')}`);
+  }
   if (isAffected && impactStyle) {
     titleParts.push(impactStyle.label);
   }
@@ -151,9 +180,11 @@ export function ShiftCell({
           // Error/warning states (override affected)
           hasError && 'bg-red-100 border-red-400 ring-2 ring-red-500 hover:bg-red-200',
           hasWarning && !hasError && 'border-yellow-400 ring-2 ring-yellow-500 hover:bg-yellow-100',
-          !hasError && !hasWarning && !isAffected && !isLocked && 'border-gray-200 hover:border-gray-300',
+          !hasError && !hasWarning && !isAffected && !isLocked && !hasExclusions && 'border-gray-200 hover:border-gray-300',
           // Locked state
           isLocked && !hasError && !hasWarning && 'ring-2 ring-green-500 border-green-400',
+          // Excluded state
+          hasExclusions && !isLocked && !hasError && !hasWarning && 'ring-2 ring-red-400 border-red-300',
           // Ineligible assignment indicator
           isIneligible && 'ring-2 ring-red-300 ring-inset border-dashed',
           // Pressing feedback (for long-press)
@@ -171,6 +202,12 @@ export function ShiftCell({
             🔒
           </span>
         )}
+        {/* Exclusion indicator */}
+        {hasExclusions && !isLocked && (
+          <span className="absolute -top-1 -right-1 text-[10px] leading-none" aria-label={`${excludedShifts.join(',')} 배제됨`}>
+            ❌
+          </span>
+        )}
       </button>
 
       {/* Context Menu */}
@@ -179,6 +216,44 @@ export function ShiftCell({
           <ContextMenuItem onClick={handleToggleLock}>
             {isLocked ? '🔓 고정 해제' : '🔒 고정'}
           </ContextMenuItem>
+          {showExclusionSection && (
+            <>
+              <div className="px-3 py-1.5 text-xs font-medium text-gray-500 border-t border-gray-100">
+                배제
+              </div>
+              <div className="flex gap-1 px-3 py-1.5">
+                {availableForExclusion.map((shiftType) => {
+                  const isExcluded = excludedShifts.includes(shiftType);
+                  const canToggle = isExcluded || excludedShifts.length < maxExclusions;
+                  return (
+                    <button
+                      key={shiftType}
+                      type="button"
+                      onClick={() => onToggleExclusion?.(shiftType)}
+                      disabled={!canToggle}
+                      aria-pressed={isExcluded}
+                      title={
+                        isExcluded
+                          ? `${shiftType} 배제 해제`
+                          : canToggle
+                            ? `${shiftType} 배제`
+                            : `최대 ${maxExclusions}개까지 배제 가능`
+                      }
+                      className={cn(
+                        'w-8 h-7 rounded border text-xs font-semibold transition-colors',
+                        isExcluded
+                          ? `${EXCLUSION_BUTTON_STYLES[shiftType]} line-through opacity-60`
+                          : 'bg-gray-50 text-gray-400 border-gray-200 hover:bg-gray-100',
+                        !canToggle && !isExcluded && 'opacity-30 cursor-not-allowed'
+                      )}
+                    >
+                      {shiftType}
+                    </button>
+                  );
+                })}
+              </div>
+            </>
+          )}
           <ContextMenuItem onClick={handleReset}>
             ↺ 초기화
           </ContextMenuItem>

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -250,11 +250,20 @@ export function useSchedule() {
 
   const removeStaff = useCallback((staffId: string) => {
     setStaff((prev) => prev.filter((s) => s.id !== staffId));
-    // Also remove assignments for this staff
-    setSchedule((prev) => ({
-      ...prev,
-      assignments: prev.assignments.filter((a) => a.staffId !== staffId),
-    }));
+    // Also remove assignments and exclusions for this staff
+    setSchedule((prev) => {
+      const newCellExclusions = { ...(prev.cellExclusions ?? {}) };
+      for (const key of Object.keys(newCellExclusions)) {
+        if (key.startsWith(`${staffId}-`)) {
+          delete newCellExclusions[key];
+        }
+      }
+      return {
+        ...prev,
+        assignments: prev.assignments.filter((a) => a.staffId !== staffId),
+        cellExclusions: newCellExclusions,
+      };
+    });
     setPreviousPeriodEnd((prev) => prev.filter((a) => a.staffId !== staffId));
   }, [setStaff, setSchedule, setPreviousPeriodEnd]);
 
@@ -264,17 +273,34 @@ export function useSchedule() {
         prev.map((s) => (s.id === staffId ? { ...s, ...updates } : s))
       );
 
-      // Remove assignments that are no longer eligible after eligibility change
+      // Remove assignments and clean up stale exclusions after eligibility change
       if (updates.eligibleShifts) {
         const newEligible = updates.eligibleShifts;
-        setSchedule((prev) => ({
-          ...prev,
-          assignments: prev.assignments.filter((a) => {
-            if (a.staffId !== staffId) return true;
-            if (a.shift === 'OFF') return true;
-            return newEligible.includes(a.shift as typeof newEligible[number]);
-          }),
-        }));
+        setSchedule((prev) => {
+          // Clean up exclusions for shift types no longer eligible
+          const newCellExclusions = { ...(prev.cellExclusions ?? {}) };
+          for (const [key, excluded] of Object.entries(newCellExclusions)) {
+            if (key.startsWith(`${staffId}-`)) {
+              const filtered = excluded.filter(
+                (s) => s === 'OFF' || newEligible.includes(s as typeof newEligible[number])
+              );
+              if (filtered.length === 0) {
+                delete newCellExclusions[key];
+              } else {
+                newCellExclusions[key] = filtered;
+              }
+            }
+          }
+          return {
+            ...prev,
+            assignments: prev.assignments.filter((a) => {
+              if (a.staffId !== staffId) return true;
+              if (a.shift === 'OFF') return true;
+              return newEligible.includes(a.shift as typeof newEligible[number]);
+            }),
+            cellExclusions: newCellExclusions,
+          };
+        });
       }
     },
     [setStaff, setSchedule]
@@ -312,6 +338,11 @@ export function useSchedule() {
           (a) => a.staffId === staffId && a.date === date
         );
 
+        // Clear exclusions when locking (mutual exclusivity)
+        const key = `${staffId}-${date}`;
+        const newCellExclusions = { ...(prev.cellExclusions ?? {}) };
+        delete newCellExclusions[key];
+
         if (existingIndex >= 0) {
           // Toggle lock on existing assignment
           const newAssignments = [...prev.assignments];
@@ -319,7 +350,7 @@ export function useSchedule() {
             ...newAssignments[existingIndex],
             isLocked: !newAssignments[existingIndex].isLocked,
           };
-          return { ...prev, assignments: newAssignments };
+          return { ...prev, assignments: newAssignments, cellExclusions: newCellExclusions };
         } else {
           // Empty cell: create OFF assignment with lock
           return {
@@ -328,8 +359,87 @@ export function useSchedule() {
               ...prev.assignments,
               { staffId, date, shift: 'OFF' as ShiftType, isLocked: true },
             ],
+            cellExclusions: newCellExclusions,
           };
         }
+      });
+    },
+    [setSchedule]
+  );
+
+  const toggleExclusion = useCallback(
+    (staffId: string, date: string, shift: ShiftType) => {
+      const staffMember = staff.find((s) => s.id === staffId);
+      if (!staffMember) return;
+
+      const eligible = getEligibleShifts(staffMember);
+      const available: ShiftType[] = [...eligible, 'OFF'];
+      const maxExclusions = Math.min(2, available.length - 2);
+
+      setSchedule((prev) => {
+        const key = `${staffId}-${date}`;
+        const currentExclusions = prev.cellExclusions?.[key] ?? [];
+        const isExcluded = currentExclusions.includes(shift);
+
+        let newExclusions: ShiftType[];
+        if (isExcluded) {
+          newExclusions = currentExclusions.filter((s) => s !== shift);
+        } else {
+          if (currentExclusions.length >= maxExclusions) return prev;
+          newExclusions = [...currentExclusions, shift];
+        }
+
+        // Update cellExclusions map
+        const newCellExclusions = { ...(prev.cellExclusions ?? {}) };
+        if (newExclusions.length === 0) {
+          delete newCellExclusions[key];
+        } else {
+          newCellExclusions[key] = newExclusions;
+        }
+
+        // If newly excluded shift matches current assignment, remove it (→ null/unassigned)
+        let newAssignments = prev.assignments;
+        if (!isExcluded) {
+          const assignmentIdx = prev.assignments.findIndex(
+            (a) => a.staffId === staffId && a.date === date
+          );
+          if (assignmentIdx >= 0 && prev.assignments[assignmentIdx].shift === shift) {
+            // Assignment removed entirely — lock goes with it
+            newAssignments = prev.assignments.filter((_, i) => i !== assignmentIdx);
+          } else if (assignmentIdx >= 0 && prev.assignments[assignmentIdx].isLocked) {
+            // Assignment kept but clear its lock (mutual exclusivity guard)
+            newAssignments = [...prev.assignments];
+            newAssignments[assignmentIdx] = { ...newAssignments[assignmentIdx], isLocked: false };
+          }
+        }
+
+        return { ...prev, assignments: newAssignments, cellExclusions: newCellExclusions };
+      });
+    },
+    [staff, setSchedule]
+  );
+
+  const resetCell = useCallback(
+    (staffId: string, date: string) => {
+      setSchedule((prev) => {
+        const existingIndex = prev.assignments.findIndex(
+          (a) => a.staffId === staffId && a.date === date
+        );
+
+        // Set shift to OFF
+        let newAssignments: ShiftAssignment[];
+        if (existingIndex >= 0) {
+          newAssignments = [...prev.assignments];
+          newAssignments[existingIndex] = { staffId, date, shift: 'OFF' };
+        } else {
+          newAssignments = [...prev.assignments, { staffId, date, shift: 'OFF' as ShiftType }];
+        }
+
+        // Clear exclusions
+        const newCellExclusions = { ...(prev.cellExclusions ?? {}) };
+        delete newCellExclusions[`${staffId}-${date}`];
+
+        return { ...prev, assignments: newAssignments, cellExclusions: newCellExclusions };
       });
     },
     [setSchedule]
@@ -339,8 +449,9 @@ export function useSchedule() {
     setSchedule((prev) => ({
       ...prev,
       startDate: date,
-      // Clear assignments when period changes
+      // Clear assignments and exclusions when period changes
       assignments: [],
+      cellExclusions: {},
     }));
     setPreviousPeriodEnd([]);
   }, [setSchedule, setPreviousPeriodEnd]);
@@ -349,6 +460,7 @@ export function useSchedule() {
     setSchedule((prev) => ({
       ...prev,
       assignments: [],
+      cellExclusions: {},
     }));
     toast.success('근무표가 초기화되었습니다.');
   }, [setSchedule]);
@@ -400,11 +512,22 @@ export function useSchedule() {
         return;
       }
 
+      // Build cell exclusions array for API
+      const cellExclusionsList = Object.entries(schedule.cellExclusions ?? {}).map(([key, shifts]) => {
+        const separatorIdx = key.indexOf('-');
+        return {
+          staffId: key.substring(0, separatorIdx),
+          date: key.substring(separatorIdx + 1),
+          excludedShifts: shifts,
+        };
+      });
+
       // Proceed with actual generation
       const response = await generateSchedule({
         ...requestPayload,
         previousPeriodEnd: previousPeriodEnd.length > 0 ? previousPeriodEnd : undefined,
         lockedAssignments: lockedAssignments.length > 0 ? lockedAssignments : undefined,
+        cellExclusions: cellExclusionsList.length > 0 ? cellExclusionsList : undefined,
       });
 
       if (response.success && response.schedule) {
@@ -442,7 +565,7 @@ export function useSchedule() {
       const message = error instanceof Error ? error.message : '알 수 없는 오류';
       toast.error(`API 오류: ${message}`);
     }
-  }, [staff, schedule.startDate, schedule.assignments, config, previousPeriodEnd, setSchedule]);
+  }, [staff, schedule.startDate, schedule.assignments, schedule.cellExclusions, config, previousPeriodEnd, setSchedule]);
 
   // ==================== Export/Import Actions ====================
 
@@ -505,6 +628,8 @@ export function useSchedule() {
     // Schedule actions
     updateAssignment,
     toggleLock,
+    toggleExclusion,
+    resetCell,
     setStartDate,
     clearSchedule,
     setPreviousPeriodEnd,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -31,6 +31,7 @@ export interface GenerateRequest {
   };
   previousPeriodEnd?: ShiftAssignment[];
   lockedAssignments?: ShiftAssignment[];
+  cellExclusions?: Array<{ staffId: string; date: string; excludedShifts: string[] }>;
 }
 
 export interface GenerateResponse {

--- a/src/types/schedule.ts
+++ b/src/types/schedule.ts
@@ -15,6 +15,8 @@ export interface Schedule {
   startDate: string;
   assignments: ShiftAssignment[];
   staffJuhuDays?: Array<{ staffId: string; juhuDay: DayOfWeek }>;
+  /** Cell-level shift exclusions. Key: getCellKey(staffId, date), Value: excluded ShiftTypes */
+  cellExclusions?: Record<string, ShiftType[]>;
 }
 
 export interface PreviousPeriodData {


### PR DESCRIPTION
## 요약
- Lock(🔒)의 역연산으로 셀 단위 근무 배제(❌) 기능 추가
- 우클릭 context menu에서 D/E/N/OFF 인라인 토글 (최대 2개 배제)
- Lock과 배제는 상호 배타 (free | locked | excluded)
- 배제 데이터를 `Schedule.cellExclusions`에 별도 저장하여 assignment 부재와 공존

## 변경 사항
- `Schedule` 타입에 `cellExclusions?: Record<string, ShiftType[]>` 추가
- `useSchedule` hook에 `toggleExclusion`, `resetCell` 추가 및 관련 함수 연동
- `ShiftCell` context menu에 배제 토글 인라인 UI (❌ 뱃지 + red ring)
- 수동 편집 시 배제된 타입 cycle에서 skip
- `GenerateRequest`에 `cellExclusions` 필드 추가 (solver hard constraint 전달)
- Backend: HARD CONSTRAINT 0.7 — cell-level `model.Add(shifts[...] == 0)`

## 설계 결정
- **상호 배타**: 3배제 ≅ 1잠금 동형이므로 max 2 배제 (`min(2, available - 2)`)
- **Option B**: cellExclusions를 Schedule에 분리 저장 — assignment와 독립적 lifecycle
- **빈 셀**: 미배정 셀에서 새 배제 불가, 기존 배제는 유지/관리 가능

## Test plan
'- [x] 
> shift-schedule@0.0.0 build
> tsc -b && vite build

vite v7.3.0 building client environment for production...
transforming...
✓ 2645 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                   0.59 kB │ gzip:   0.36 kB
dist/assets/index-Dn6ckAoo.css   37.24 kB │ gzip:   6.86 kB
dist/assets/index-DxtYGR3x.js   415.05 kB │ gzip: 125.53 kB
✓ built in 2.92s 빌드 성공 확인'
'- [x] 
> shift-schedule@0.0.0 test
> vitest run


[1m[46m RUN [49m[22m [36mv4.0.16 [39m[90m/Users/choi/Downloads/github/private/shift-schedule[39m

 [32m✓[39m src/constraints/__tests__/monthlyNight.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/constraints/__tests__/consecutiveNight.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 39[2mms[22m[39m
 [32m✓[39m src/constraints/__tests__/staffing.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/constraints/__tests__/nightOffDay.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/constraints/__tests__/maxPeriodOff.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/constraints/__tests__/weeklyOff.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/constraints/__tests__/maxConsecutiveOff.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 40[2mms[22m[39m
 [32m✓[39m src/constraints/__tests__/maxConsecutiveWork.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m src/constraints/__tests__/shiftOrder.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 7[2mms[22m[39m

[2m Test Files [22m [1m[32m9 passed[39m[22m[90m (9)[39m
[2m      Tests [22m [1m[32m53 passed[39m[22m[90m (53)[39m
[2m   Start at [22m 00:33:49
[2m   Duration [22m 3.17s[2m (transform 405ms, setup 1.12s, import 14.41s, tests 140ms, environment 6.95s)[22m 기존 테스트 전체 통과 확인'
- [ ] 셀 우클릭 → context menu에 "배제" 섹션과 D/E/N/OFF 토글 버튼 표시 확인
- [ ] 배제 토글 시 ❌ 뱃지와 red ring 시각 표시 확인
- [ ] 배제된 타입이 셀 클릭 cycle에서 skip되는지 확인
- [ ] Lock 설정 시 배제 자동 해제, 배제 설정 시 Lock 자동 해제 확인
- [ ] 현재 shift와 동일한 타입 배제 시 셀이 미배정(null)으로 리셋되는지 확인
- [ ] 초기화(↺) 클릭 시 배제도 함께 초기화되는지 확인
- [ ] 자동 생성 시 배제된 셀에 해당 근무가 배정되지 않는지 확인
- [ ] 직원 삭제/기간 변경/근무표 초기화 시 exclusion 데이터 정리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)