### PR TITLE
주차별 구분선 추가로 스케줄 그리드 가독성 향상

### DIFF
--- a/src/components/ScheduleGrid.tsx
+++ b/src/components/ScheduleGrid.tsx
@@ -43,13 +43,14 @@ export function ScheduleGrid({
   } | null>(null);
   // Generate 28 dates from schedule.startDate
   const dates = useMemo(() => {
-    const result: { date: Date; dateString: string }[] = [];
+    const result: { date: Date; dateString: string; isWeekStart: boolean }[] = [];
     const start = parseISO(schedule.startDate);
     for (let i = 0; i < 28; i++) {
       const date = addDays(start, i);
       result.push({
         date,
         dateString: format(date, 'yyyy-MM-dd'),
+        isWeekStart: i > 0 && date.getDay() === 0,
       });
     }
     return result;
@@ -135,13 +136,14 @@ export function ScheduleGrid({
             >
               직원
             </th>
-            {dates.map(({ date, dateString }) => (
+            {dates.map(({ date, dateString, isWeekStart }) => (
               <th
                 key={dateString}
                 scope="col"
                 className={cn(
                   'p-2 border-b border-gray-200 text-center text-xs font-medium whitespace-nowrap',
-                  isWeekend(date) ? 'bg-slate-200 text-slate-700' : 'bg-gray-50 text-gray-600'
+                  isWeekend(date) ? 'bg-slate-200 text-slate-700' : 'bg-gray-50 text-gray-600',
+                  isWeekStart && 'border-l-2 border-l-gray-300'
                 )}
               >
                 {formatDateKorean(date)}
@@ -229,7 +231,7 @@ export function ScheduleGrid({
                     );
                   })()}
                 </td>
-                {dates.map(({ date, dateString }) => {
+                {dates.map(({ date, dateString, isWeekStart }) => {
                   const key = getCellKey(staffMember.id, dateString);
                   const assignment = assignmentMap.get(key);
                   const cellViolations = violationMap.get(key) || [];
@@ -240,7 +242,8 @@ export function ScheduleGrid({
                       className={cn(
                         'p-1 border-b border-gray-200',
                         isWeekend(date) && 'bg-slate-100',
-                        isLastRow && 'border-b-0'
+                        isLastRow && 'border-b-0',
+                        isWeekStart && 'border-l-2 border-l-gray-300'
                       )}
                     >
                       <ShiftCell
@@ -314,14 +317,15 @@ export function ScheduleGrid({
             <td className="sticky left-0 z-10 bg-amber-50 p-2 border-t border-r border-gray-200 text-sm font-medium text-amber-600">
               D 인원
             </td>
-            {dates.map(({ date, dateString }) => {
+            {dates.map(({ date, dateString, isWeekStart }) => {
               const counts = perDateCounts.get(dateString);
               return (
                 <td
                   key={dateString}
                   className={cn(
                     'p-2 border-t border-gray-200 text-center text-sm font-medium text-amber-600',
-                    isWeekend(date) && 'bg-amber-200/70'
+                    isWeekend(date) && 'bg-amber-200/70',
+                    isWeekStart && 'border-l-2 border-l-gray-300'
                   )}
                 >
                   {counts?.D ?? 0}
@@ -338,14 +342,15 @@ export function ScheduleGrid({
             <td className="sticky left-0 z-10 bg-blue-50 p-2 border-r border-gray-200 text-sm font-medium text-blue-600">
               E 인원
             </td>
-            {dates.map(({ date, dateString }) => {
+            {dates.map(({ date, dateString, isWeekStart }) => {
               const counts = perDateCounts.get(dateString);
               return (
                 <td
                   key={dateString}
                   className={cn(
                     'p-2 text-center text-sm font-medium text-blue-600',
-                    isWeekend(date) && 'bg-blue-200/70'
+                    isWeekend(date) && 'bg-blue-200/70',
+                    isWeekStart && 'border-l-2 border-l-gray-300'
                   )}
                 >
                   {counts?.E ?? 0}
@@ -362,14 +367,15 @@ export function ScheduleGrid({
             <td className="sticky left-0 z-10 bg-purple-50 p-2 border-r border-gray-200 text-sm font-medium text-purple-600">
               N 인원
             </td>
-            {dates.map(({ date, dateString }) => {
+            {dates.map(({ date, dateString, isWeekStart }) => {
               const counts = perDateCounts.get(dateString);
               return (
                 <td
                   key={dateString}
                   className={cn(
                     'p-2 text-center text-sm font-medium text-purple-600',
-                    isWeekend(date) && 'bg-purple-200/70'
+                    isWeekend(date) && 'bg-purple-200/70',
+                    isWeekStart && 'border-l-2 border-l-gray-300'
                   )}
                 >
                   {counts?.N ?? 0}


### PR DESCRIPTION
## Summary
- 28일 스케줄 그리드에서 일요일 열에 좌측 테두리(border-l-2)를 추가하여 주차별 구분선 표시
- 헤더, 바디, 풋터(D/E/N 인원) 5곳 모두 일관되게 적용
- dates 배열에 isWeekStart 플래그를 한번 계산하여 재사용

## Test plan
- [ ] `npm run build` 빌드 성공 확인
- [ ] `npm test` 테스트 전체 통과 확인
- [ ] 브라우저에서 스케줄 그리드 열어 일요일 열에 구분선이 표시되는지 확인
- [ ] 시작일이 월요일(2025-01-06)일 때 첫 번째 열에는 구분선 없고 7번째 열(일요일)부터 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
