### PR TITLE
수익화 v1: 인증·결제·법적준수·가격페이지 (TossPayments 카드사 심사 prerequisite)

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 VITE_SOLVER_API_URL=https://4jyos1w157.execute-api.ap-northeast-2.amazonaws.com
+VITE_API_URL=https://9e240d7v0k.execute-api.ap-northeast-2.amazonaws.com/api

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,8 @@ jobs:
         run: npm ci
 
       - name: Build
+        env:
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
         run: npm run build
 
       - name: Setup Pages

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Skill runtime data
+hypomnesis/

--- a/index.html
+++ b/index.html
@@ -6,6 +6,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
     <title>Shift Schedule</title>
+    <script>
+      // GitHub Pages SPA fallback decoder — pairs with public/404.html.
+      (function (l) {
+        if (l.search[1] === '/') {
+          var decoded = l.search
+            .slice(1)
+            .split('&')
+            .map(function (s) {
+              return s.replace(/~and~/g, '&');
+            })
+            .join('?');
+          window.history.replaceState(null, '', l.pathname.slice(0, -1) + decoded + l.hash);
+        }
+      })(window.location);
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Shift Schedule</title>
+    <script>
+      // GitHub Pages SPA fallback (rafgraph/spa-github-pages pattern).
+      // Encodes the requested path into the query string and redirects to /,
+      // where index.html decodes it back via history.replaceState.
+      (function () {
+        var pathSegmentsToKeep = 0;
+        var l = window.location;
+        l.replace(
+          l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+          l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+          l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+          (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+          l.hash
+        );
+      })();
+    </script>
+  </head>
+  <body>
+    <noscript>
+      JavaScript가 비활성화되어 있습니다. <a href="/">홈으로 이동</a>
+    </noscript>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Toaster, toast } from 'sonner';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { StaffList } from '@/components/StaffList';
@@ -8,10 +9,20 @@ import { ViolationList } from '@/components/ViolationList';
 import { PeriodSelector } from '@/components/PeriodSelector';
 import { PreviousPeriodInput } from '@/components/PreviousPeriodInput';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { LoginPrompt } from '@/components/LoginPrompt';
+import { UpgradePrompt } from '@/components/UpgradePrompt';
+import { UserMenu } from '@/components/UserMenu';
+import { GenerationCounter } from '@/components/GenerationCounter';
 import { useSchedule } from '@/hooks/useSchedule';
-import { isApiConfigured } from '@/services/solverApi';
+import { useAuth } from '@/contexts/AuthContext';
+import { isApiConfigured, getLastRemainingCount } from '@/services/solverApi';
+import { GenerationLimitError } from '@/types/auth';
 
 function App() {
+  const { user, isAuthenticated } = useAuth();
+  const [loginPromptOpen, setLoginPromptOpen] = useState(false);
+  const [upgradePromptOpen, setUpgradePromptOpen] = useState(false);
+
   const {
     staff,
     schedule,
@@ -40,6 +51,28 @@ function App() {
     setConfig,
     importFromJSON,
   } = useSchedule();
+
+  // Auth-gated auto-generation handler
+  const handleGenerate = async () => {
+    if (!isAuthenticated) {
+      setLoginPromptOpen(true);
+      return;
+    }
+    try {
+      await generateAutoSchedule();
+    } catch (error) {
+      if (error instanceof GenerationLimitError) {
+        setUpgradePromptOpen(true);
+      }
+      // Other errors are already handled by useSchedule via toast
+    }
+  };
+
+  const handleUpgrade = (type: 'daypass' | 'annual') => {
+    setUpgradePromptOpen(false);
+    // TODO: integrate TossPayments checkout flow
+    toast.info(`${type === 'annual' ? '연간 구독' : '데이 패스'} 결제 준비 중`);
+  };
 
   // Export handler - TSV to clipboard for spreadsheet paste
   const handleExport = async () => {
@@ -125,10 +158,27 @@ function App() {
               Shift Schedule - 교대 근무 검증하기
             </h1>
             <nav aria-label="주요 기능">
-              <div className="flex gap-2">
+              <div className="flex items-center gap-2">
+                {isAuthenticated && user && (
+                  <>
+                    <GenerationCounter
+                      remaining={getLastRemainingCount()}
+                      plan={user.plan}
+                    />
+                    <UserMenu user={user} />
+                  </>
+                )}
+                {!isAuthenticated && (
+                  <button
+                    onClick={() => setLoginPromptOpen(true)}
+                    className="px-3 py-1.5 text-sm text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+                  >
+                    로그인
+                  </button>
+                )}
                 {isApiConfigured() && (
                   <button
-                    onClick={generateAutoSchedule}
+                    onClick={handleGenerate}
                     disabled={generationStatus === 'loading' || staff.length === 0}
                     aria-label="근무표 자동 생성"
                     className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
@@ -247,6 +297,13 @@ function App() {
             </ErrorBoundary>
           </section>
         </main>
+        {/* Auth dialogs */}
+        <LoginPrompt open={loginPromptOpen} onOpenChange={setLoginPromptOpen} />
+        <UpgradePrompt
+          open={upgradePromptOpen}
+          onOpenChange={setUpgradePromptOpen}
+          onUpgrade={handleUpgrade}
+        />
       </div>
     </ErrorBoundary>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -190,6 +190,12 @@ function ScheduleApp() {
             </h1>
             <nav aria-label="주요 기능">
               <div className="flex items-center gap-2">
+                <a
+                  href="/pricing"
+                  className="px-3 py-1.5 text-sm text-gray-700 hover:text-gray-900 hover:underline transition-colors"
+                >
+                  요금제
+                </a>
                 {isAuthenticated && user && (
                   <>
                     <GenerationCounter

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Toaster, toast } from 'sonner';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { StaffList } from '@/components/StaffList';
@@ -13,15 +13,46 @@ import { LoginPrompt } from '@/components/LoginPrompt';
 import { UpgradePrompt } from '@/components/UpgradePrompt';
 import { UserMenu } from '@/components/UserMenu';
 import { GenerationCounter } from '@/components/GenerationCounter';
+import { Footer } from '@/components/Footer';
+import { PricingView } from '@/components/PricingView';
+import { TermsView } from '@/components/TermsView';
+import { PrivacyView } from '@/components/PrivacyView';
 import { useSchedule } from '@/hooks/useSchedule';
 import { useAuth } from '@/contexts/AuthContext';
 import { isApiConfigured, getLastRemainingCount } from '@/services/solverApi';
 import { GenerationLimitError } from '@/types/auth';
 
 function App() {
+  const path = typeof window !== 'undefined' ? window.location.pathname : '/';
+  if (path === '/pricing') return <PricingView />;
+  if (path === '/terms') return <TermsView />;
+  if (path === '/privacy') return <PrivacyView />;
+
+  return <ScheduleApp />;
+}
+
+function ScheduleApp() {
   const { user, isAuthenticated } = useAuth();
-  const [loginPromptOpen, setLoginPromptOpen] = useState(false);
-  const [upgradePromptOpen, setUpgradePromptOpen] = useState(false);
+  const [loginPromptOpen, setLoginPromptOpen] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return new URLSearchParams(window.location.search).get('signup') === '1';
+  });
+  const [upgradePromptOpen, setUpgradePromptOpen] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    const upgrade = new URLSearchParams(window.location.search).get('upgrade');
+    return upgrade === 'daypass' || upgrade === 'annual';
+  });
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.has('upgrade') || params.has('signup')) {
+      params.delete('upgrade');
+      params.delete('signup');
+      const cleaned = params.toString();
+      const newUrl = cleaned ? `${window.location.pathname}?${cleaned}` : window.location.pathname;
+      window.history.replaceState({}, '', newUrl);
+    }
+  }, []);
 
   const {
     staff,
@@ -304,6 +335,7 @@ function App() {
           onOpenChange={setUpgradePromptOpen}
           onUpgrade={handleUpgrade}
         />
+        <Footer />
       </div>
     </ErrorBoundary>
   );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,11 @@
 import { BUSINESS_INFO, SERVICE_INFO } from '@/config/business';
 
+const isPlaceholder = (value: string) => value.startsWith('PLACEHOLDER_');
+
 export function Footer() {
+  const showMailOrder = !isPlaceholder(BUSINESS_INFO.mailOrderRegistrationNumber);
+  const showPhone = !isPlaceholder(BUSINESS_INFO.phone);
+
   return (
     <footer className="mt-12 border-t border-gray-200 bg-gray-50">
       <div className="mx-auto max-w-6xl px-4 py-6 text-xs text-gray-600">
@@ -10,11 +15,13 @@ export function Footer() {
             <div>상호: {BUSINESS_INFO.companyName}</div>
             <div>대표: {BUSINESS_INFO.representative}</div>
             <div>사업자등록번호: {BUSINESS_INFO.businessRegistrationNumber}</div>
-            <div>통신판매업 신고번호: {BUSINESS_INFO.mailOrderRegistrationNumber}</div>
+            {showMailOrder && (
+              <div>통신판매업 신고번호: {BUSINESS_INFO.mailOrderRegistrationNumber}</div>
+            )}
           </div>
           <div className="space-y-1">
             <div>주소: {BUSINESS_INFO.address}</div>
-            <div>전화: {BUSINESS_INFO.phone}</div>
+            {showPhone && <div>전화: {BUSINESS_INFO.phone}</div>}
             <div>
               이메일: <a href={`mailto:${BUSINESS_INFO.email}`} className="underline hover:text-gray-900">{BUSINESS_INFO.email}</a>
             </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,34 @@
+import { BUSINESS_INFO, SERVICE_INFO } from '@/config/business';
+
+export function Footer() {
+  return (
+    <footer className="mt-12 border-t border-gray-200 bg-gray-50">
+      <div className="mx-auto max-w-6xl px-4 py-6 text-xs text-gray-600">
+        <div className="grid gap-3 sm:grid-cols-2 sm:gap-6">
+          <div className="space-y-1">
+            <div className="font-medium text-gray-800">{SERVICE_INFO.serviceName}</div>
+            <div>상호: {BUSINESS_INFO.companyName}</div>
+            <div>대표: {BUSINESS_INFO.representative}</div>
+            <div>사업자등록번호: {BUSINESS_INFO.businessRegistrationNumber}</div>
+            <div>통신판매업 신고번호: {BUSINESS_INFO.mailOrderRegistrationNumber}</div>
+          </div>
+          <div className="space-y-1">
+            <div>주소: {BUSINESS_INFO.address}</div>
+            <div>전화: {BUSINESS_INFO.phone}</div>
+            <div>
+              이메일: <a href={`mailto:${BUSINESS_INFO.email}`} className="underline hover:text-gray-900">{BUSINESS_INFO.email}</a>
+            </div>
+            <div>호스팅: {BUSINESS_INFO.hosting}</div>
+          </div>
+        </div>
+        <nav className="mt-4 flex flex-wrap gap-x-4 gap-y-1 border-t border-gray-200 pt-4">
+          <a href="/pricing" className="hover:text-gray-900 hover:underline">요금제</a>
+          <a href="/terms" className="hover:text-gray-900 hover:underline">이용약관</a>
+          <a href="/privacy" className="hover:text-gray-900 hover:underline">개인정보처리방침</a>
+          <a href="/terms#refund" className="hover:text-gray-900 hover:underline">환불정책</a>
+          <span className="ml-auto text-gray-400">© 2026 {BUSINESS_INFO.companyName}. All rights reserved.</span>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/GenerationCounter.tsx
+++ b/src/components/GenerationCounter.tsx
@@ -1,0 +1,38 @@
+/**
+ * Compact badge showing remaining generation count or plan status.
+ * Displayed in the header bar for authenticated users.
+ */
+
+import type { Plan } from '@/types/auth';
+
+interface GenerationCounterProps {
+  remaining: number | null;
+  plan: Plan;
+}
+
+export function GenerationCounter({ remaining, plan }: GenerationCounterProps) {
+  if (remaining === null && plan === 'free') return null;
+
+  if (plan === 'annual') {
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-blue-100 text-blue-700">
+        Annual
+      </span>
+    );
+  }
+
+  if (plan === 'daypass') {
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-amber-100 text-amber-700">
+        Day Pass
+      </span>
+    );
+  }
+
+  // Free plan with remaining count
+  return (
+    <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-gray-100 text-gray-600">
+      남은 무료 생성: {remaining}회
+    </span>
+  );
+}

--- a/src/components/LoginPrompt.tsx
+++ b/src/components/LoginPrompt.tsx
@@ -1,0 +1,142 @@
+/**
+ * Login dialog shown when unauthenticated user clicks "자동 생성".
+ * Uses Google Identity Services for sign-in.
+ */
+
+import { useCallback, useEffect, useRef } from 'react';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useAuth } from '@/contexts/AuthContext';
+
+interface LoginPromptProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+declare global {
+  interface Window {
+    google?: {
+      accounts: {
+        id: {
+          initialize: (config: {
+            client_id: string;
+            callback: (response: { credential: string }) => void;
+            auto_select?: boolean;
+          }) => void;
+          renderButton: (
+            parent: HTMLElement,
+            options: {
+              theme?: string;
+              size?: string;
+              width?: number;
+              text?: string;
+              shape?: string;
+              locale?: string;
+            },
+          ) => void;
+        };
+      };
+    };
+  }
+}
+
+const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID ?? '';
+
+export function LoginPrompt({ open, onOpenChange }: LoginPromptProps) {
+  const { signIn } = useAuth();
+  const buttonRef = useRef<HTMLDivElement>(null);
+  const scriptLoaded = useRef(false);
+
+  const handleCredentialResponse = useCallback(
+    async (response: { credential: string }) => {
+      try {
+        await signIn(response.credential);
+        onOpenChange(false);
+        toast.success('로그인되었습니다.');
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : '로그인에 실패했습니다.';
+        toast.error(message);
+      }
+    },
+    [signIn, onOpenChange],
+  );
+
+  useEffect(() => {
+    if (!open || !GOOGLE_CLIENT_ID) return;
+
+    const initializeGoogle = () => {
+      if (!window.google || !buttonRef.current) return;
+
+      window.google.accounts.id.initialize({
+        client_id: GOOGLE_CLIENT_ID,
+        callback: handleCredentialResponse,
+      });
+
+      // Clear previous button content
+      buttonRef.current.innerHTML = '';
+
+      window.google.accounts.id.renderButton(buttonRef.current, {
+        theme: 'outline',
+        size: 'large',
+        width: 300,
+        text: 'signin_with',
+        shape: 'rectangular',
+        locale: 'ko',
+      });
+    };
+
+    if (window.google) {
+      initializeGoogle();
+      return;
+    }
+
+    if (!scriptLoaded.current) {
+      scriptLoaded.current = true;
+      const script = document.createElement('script');
+      script.src = 'https://accounts.google.com/gsi/client';
+      script.async = true;
+      script.defer = true;
+      script.onload = initializeGoogle;
+      script.onerror = () => {
+        toast.error('Google 로그인을 불러올 수 없습니다.');
+      };
+      document.head.appendChild(script);
+    }
+  }, [open, handleCredentialResponse]);
+
+  if (!GOOGLE_CLIENT_ID) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="text-center text-lg">
+            교대근무 자동 생성 서비스
+          </DialogTitle>
+          <DialogDescription className="text-center">
+            로그인하면 OR-Tools 기반 자동 스케줄링을 사용할 수 있습니다.
+            매월 3회 무료로 제공됩니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col items-center gap-4 py-2">
+          {/* Google Sign-In button rendered by GIS */}
+          <div ref={buttonRef} className="flex justify-center" />
+
+          <p className="text-xs text-muted-foreground text-center">
+            로그인 시{' '}
+            <span className="underline">이용약관</span> 및{' '}
+            <span className="underline">개인정보처리방침</span>에 동의합니다.
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/PricingView.tsx
+++ b/src/components/PricingView.tsx
@@ -1,0 +1,167 @@
+import { SERVICE_INFO } from '@/config/business';
+import { Footer } from '@/components/Footer';
+
+export function PricingView() {
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+      <main className="mx-auto max-w-4xl px-4 py-12">
+        <div className="mb-10 text-center">
+          <h1 className="text-3xl font-semibold text-gray-900">요금제</h1>
+          <p className="mt-2 text-sm text-gray-600">
+            매월 3회 무료로 시험 사용해보고, 필요할 때 부담 없이 결제하세요.
+          </p>
+        </div>
+
+        <div className="grid gap-6 sm:grid-cols-3">
+          <PlanCard
+            name="무료"
+            price="0원"
+            period="평생"
+            features={[
+              'Google 계정으로 가입',
+              '매월 자동 생성 3회',
+              '제약 검증 무제한',
+              '근무표 수동 편집 무제한',
+            ]}
+            cta="회원가입"
+            ctaHref="/?signup=1"
+            highlight={false}
+          />
+          <PlanCard
+            name="데이 패스"
+            price="3,000원"
+            period="1회 결제 / 24시간"
+            features={[
+              '24시간 자동 생성 무제한',
+              '결제 후 즉시 사용 가능',
+              '자동결제 없음',
+              '단발성 사용에 적합',
+            ]}
+            cta="데이 패스 구매"
+            ctaHref="/?upgrade=daypass"
+            highlight={false}
+          />
+          <PlanCard
+            name="연간 구독"
+            price="월 3,000원"
+            period="자동결제 / 1년 단위 갱신 / 최대 12개월"
+            features={[
+              '매월 자동 생성 무제한',
+              '월 자동결제',
+              '언제든 해지 가능',
+              '월별 사용에 적합',
+            ]}
+            cta="연간 구독 시작"
+            ctaHref="/?upgrade=annual"
+            highlight
+          />
+        </div>
+
+        <section className="mt-12 rounded-md border border-gray-200 bg-gray-50 p-6">
+          <h2 className="mb-3 text-base font-semibold text-gray-900">결제 안내</h2>
+          <dl className="space-y-2 text-sm text-gray-700">
+            <Row label="결제수단" value="신용카드, 계좌이체, 간편결제 (가상계좌 미지원)" />
+            <Row label="결제대행" value="(주)토스페이먼츠" />
+            <Row label="서비스 제공 기간" value="데이 패스 24시간 / 연간 구독 최대 12개월" />
+            <Row label="자동결제 해지" value="마이페이지 또는 고객센터 이메일을 통해 언제든지 해지 가능" />
+          </dl>
+        </section>
+
+        <section className="mt-6 rounded-md border border-amber-200 bg-amber-50 p-6 text-sm text-amber-900">
+          <h2 className="mb-2 text-base font-semibold">청약철회 안내 (디지털 콘텐츠 특례)</h2>
+          <p>
+            본 서비스는 「전자상거래 등에서의 소비자보호에 관한 법률」 제17조 제2항 제5호에 따른
+            디지털 콘텐츠로, 이용 시작 시점부터 청약철회가 제한됩니다. 결제 전 무료 3회 생성을 통해
+            서비스를 충분히 시험 사용해보시기 바랍니다. 자세한 환불 정책은{' '}
+            <a href="/terms#refund" className="underline hover:text-amber-700">
+              이용약관 제7조
+            </a>
+            를 참고하세요.
+          </p>
+        </section>
+
+        <p className="mt-10 text-center text-xs text-gray-500">
+          모든 가격은 부가세(VAT) 포함입니다. 결제 통화: KRW
+        </p>
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+function Header() {
+  return (
+    <header className="border-b border-gray-200 bg-white">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
+        <a href="/" className="text-sm font-medium text-gray-800 hover:text-gray-900">
+          ← {SERVICE_INFO.serviceName}
+        </a>
+        <nav className="flex gap-4 text-xs text-gray-600">
+          <a href="/terms" className="hover:text-gray-900 hover:underline">이용약관</a>
+          <a href="/privacy" className="hover:text-gray-900 hover:underline">개인정보처리방침</a>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+interface PlanCardProps {
+  name: string;
+  price: string;
+  period: string;
+  features: string[];
+  cta: string;
+  ctaHref: string;
+  highlight: boolean;
+}
+
+function PlanCard({ name, price, period, features, cta, ctaHref, highlight }: PlanCardProps) {
+  const containerClass = highlight
+    ? 'border-blue-500 ring-2 ring-blue-100'
+    : 'border-gray-200';
+  const buttonClass = highlight
+    ? 'bg-blue-600 text-white hover:bg-blue-700'
+    : 'border border-gray-300 text-gray-800 hover:bg-gray-50';
+
+  return (
+    <div className={`flex flex-col rounded-lg border bg-white p-6 ${containerClass}`}>
+      {highlight && (
+        <span className="mb-2 self-start rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-medium text-blue-700">
+          추천
+        </span>
+      )}
+      <h3 className="text-lg font-semibold text-gray-900">{name}</h3>
+      <div className="mt-3 text-3xl font-semibold text-gray-900">{price}</div>
+      <div className="mt-1 text-xs text-gray-500">{period}</div>
+      <ul className="mt-5 flex-1 space-y-1.5 text-sm text-gray-700">
+        {features.map((f) => (
+          <li key={f} className="flex items-start gap-2">
+            <span className="mt-0.5 text-blue-500">•</span>
+            <span>{f}</span>
+          </li>
+        ))}
+      </ul>
+      <a
+        href={ctaHref}
+        className={`mt-6 block rounded-md px-4 py-2.5 text-center text-sm font-medium transition-colors ${buttonClass}`}
+      >
+        {cta}
+      </a>
+    </div>
+  );
+}
+
+interface RowProps {
+  label: string;
+  value: string;
+}
+
+function Row({ label, value }: RowProps) {
+  return (
+    <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-3">
+      <dt className="w-32 shrink-0 font-medium text-gray-600">{label}</dt>
+      <dd className="text-gray-800">{value}</dd>
+    </div>
+  );
+}

--- a/src/components/PrivacyView.tsx
+++ b/src/components/PrivacyView.tsx
@@ -1,0 +1,187 @@
+import { BUSINESS_INFO, SERVICE_INFO } from '@/config/business';
+import { Footer } from '@/components/Footer';
+
+export function PrivacyView() {
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+      <article className="mx-auto max-w-3xl px-4 py-10 text-sm leading-relaxed text-gray-800">
+        <h1 className="mb-2 text-2xl font-semibold text-gray-900">개인정보처리방침</h1>
+        <p className="mb-8 text-xs text-gray-500">시행일: {SERVICE_INFO.effectiveDate}</p>
+
+        <p className="mb-6">
+          {BUSINESS_INFO.companyName}(이하 "회사")는 「개인정보 보호법」 등 관련 법령에 따라 이용자의 개인정보를
+          보호하고 권익을 보장하기 위해 다음과 같이 개인정보처리방침을 수립·공개합니다.
+        </p>
+
+        <Section title="제1조 (수집하는 개인정보 항목)">
+          <p className="mb-2">회사는 서비스 제공을 위해 다음의 개인정보를 수집합니다.</p>
+          <table className="w-full border-collapse text-xs">
+            <thead>
+              <tr className="border-y border-gray-300 bg-gray-50">
+                <th className="px-2 py-2 text-left font-medium">구분</th>
+                <th className="px-2 py-2 text-left font-medium">수집 항목</th>
+                <th className="px-2 py-2 text-left font-medium">수집 시점</th>
+              </tr>
+            </thead>
+            <tbody>
+              <Row label="회원가입 (Google OAuth)" items="이메일, 이름, 프로필 이미지, Google 계정 식별자" timing="회원가입 시" />
+              <Row label="유료 결제" items="결제수단 식별자(billing key), 결제 이력 (실제 카드번호는 (주)토스페이먼츠가 보관, 회사는 미보관)" timing="유료 상품 결제 시" />
+              <Row label="서비스 이용" items="자동 생성 횟수, 마지막 이용 일시, 접속 IP, 브라우저 정보" timing="서비스 이용 시 자동 수집" />
+            </tbody>
+          </table>
+        </Section>
+
+        <Section title="제2조 (개인정보의 수집 및 이용 목적)">
+          <ol className="list-decimal space-y-1 pl-5">
+            <li><strong>회원 식별 및 인증</strong>: 본인 확인, 부정 이용 방지</li>
+            <li><strong>서비스 제공</strong>: 자동 스케줄 생성 한도 관리, 유료 상품 이용 권한 부여</li>
+            <li><strong>결제 처리</strong>: 결제대행을 통한 유료 상품 결제 및 정산</li>
+            <li><strong>고객 응대</strong>: 문의 응답, 환불 처리, 결제 실패 안내 이메일 발송</li>
+            <li><strong>서비스 개선</strong>: 이용 통계 분석 (개인 식별 정보 제외)</li>
+          </ol>
+        </Section>
+
+        <Section title="제3조 (개인정보의 보유 및 이용 기간)">
+          <ol className="list-decimal space-y-1 pl-5">
+            <li>회원 정보: 회원 탈퇴 시까지</li>
+            <li>결제 기록: 「전자상거래법」에 따라 5년간 보관</li>
+            <li>접속 기록: 「통신비밀보호법」에 따라 3개월간 보관</li>
+            <li>탈퇴 회원의 정보는 즉시 파기되며, 위 법정 보관 기간이 적용되는 결제·접속 기록은 별도 분리하여 보관됩니다.</li>
+          </ol>
+        </Section>
+
+        <Section title="제4조 (개인정보의 제3자 제공)">
+          <p className="mb-2">회사는 이용자의 동의 없이 개인정보를 제3자에게 제공하지 않습니다. 단, 다음의 경우 예외로 합니다.</p>
+          <ul className="list-disc space-y-0.5 pl-5">
+            <li>이용자가 사전에 동의한 경우</li>
+            <li>법령에 의거하거나 수사기관의 요구가 있는 경우</li>
+          </ul>
+        </Section>
+
+        <Section title="제5조 (개인정보 처리의 위탁)">
+          <p className="mb-2">회사는 원활한 서비스 제공을 위해 다음과 같이 개인정보 처리를 위탁하고 있습니다.</p>
+          <table className="w-full border-collapse text-xs">
+            <thead>
+              <tr className="border-y border-gray-300 bg-gray-50">
+                <th className="px-2 py-2 text-left font-medium">수탁자</th>
+                <th className="px-2 py-2 text-left font-medium">위탁 업무</th>
+              </tr>
+            </thead>
+            <tbody>
+              <SimpleRow vendor="(주)토스페이먼츠" task="결제 대행, 카드정보 보관, 빌링키 관리" />
+              <SimpleRow vendor="Amazon Web Services, Inc." task="서버 인프라, 데이터베이스, 이메일 발송" />
+              <SimpleRow vendor="Google LLC" task="OAuth 2.0 인증" />
+              <SimpleRow vendor="Microsoft (GitHub Pages)" task="정적 콘텐츠 호스팅" />
+            </tbody>
+          </table>
+        </Section>
+
+        <Section title="제6조 (정보주체의 권리·의무 및 행사방법)">
+          <ol className="list-decimal space-y-1 pl-5">
+            <li>이용자는 언제든지 자신의 개인정보를 조회·수정·삭제·처리정지를 요청할 수 있습니다.</li>
+            <li>권리 행사는 회사에 대해 서면, 이메일, 모사전송(FAX) 등을 통해 하실 수 있으며 회사는 이에 대해
+              지체 없이 조치하겠습니다.</li>
+            <li>이용자가 개인정보의 오류 등에 대한 정정 또는 삭제를 요구한 경우, 회사는 정정 또는 삭제를 완료할
+              때까지 당해 개인정보를 이용하거나 제공하지 않습니다.</li>
+          </ol>
+        </Section>
+
+        <Section title="제7조 (개인정보의 안전성 확보 조치)">
+          <ol className="list-decimal space-y-1 pl-5">
+            <li>관리적 조치: 개인정보 취급자 최소화 및 정기 교육</li>
+            <li>기술적 조치: 접근권한 관리, 암호화 전송 (HTTPS/TLS), 결제수단 토큰화</li>
+            <li>물리적 조치: 데이터센터 물리 접근 제한 (AWS 표준)</li>
+          </ol>
+        </Section>
+
+        <Section title="제8조 (개인정보 자동 수집 장치의 설치·운영 및 거부)">
+          <p>회사는 서비스 이용 편의 제공을 위해 쿠키 또는 로컬 스토리지(localStorage)를 사용할 수 있습니다.
+            이용자는 브라우저 설정을 통해 쿠키 저장을 거부할 수 있으나, 이 경우 일부 기능 이용에 제한이 있을 수 있습니다.</p>
+        </Section>
+
+        <Section title="제9조 (개인정보 보호책임자)">
+          <ul className="list-disc space-y-0.5 pl-5">
+            <li>이름: {BUSINESS_INFO.privacyOfficer.name}</li>
+            <li>이메일: <a href={`mailto:${BUSINESS_INFO.privacyOfficer.email}`} className="underline">{BUSINESS_INFO.privacyOfficer.email}</a></li>
+          </ul>
+          <p className="mt-2 text-xs text-gray-600">
+            기타 개인정보 침해에 대한 신고나 상담이 필요한 경우 다음 기관에 문의하실 수 있습니다.
+          </p>
+          <ul className="mt-1 list-disc space-y-0.5 pl-5 text-xs text-gray-600">
+            <li>개인정보분쟁조정위원회: 1833-6972 (privacy.go.kr)</li>
+            <li>개인정보침해신고센터: 118 (privacy.kisa.or.kr)</li>
+            <li>대검찰청 사이버범죄수사단: 02-3480-3573</li>
+            <li>경찰청 사이버수사국: 182 (ecrm.cyber.go.kr)</li>
+          </ul>
+        </Section>
+
+        <Section title="제10조 (개인정보처리방침의 변경)">
+          본 방침은 시행일로부터 적용되며, 법령 및 방침에 따른 변경 내용의 추가, 삭제 및 정정이 있는 경우에는
+          변경사항의 시행 7일 전부터 공지합니다.
+        </Section>
+
+        <p className="mt-10 border-t border-gray-200 pt-4 text-xs text-gray-500">
+          부칙: 본 방침은 {SERVICE_INFO.effectiveDate}부터 시행됩니다.
+        </p>
+      </article>
+      <Footer />
+    </div>
+  );
+}
+
+function Header() {
+  return (
+    <header className="border-b border-gray-200 bg-white">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
+        <a href="/" className="text-sm font-medium text-gray-800 hover:text-gray-900">
+          ← {SERVICE_INFO.serviceName}
+        </a>
+      </div>
+    </header>
+  );
+}
+
+interface SectionProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+function Section({ title, children }: SectionProps) {
+  return (
+    <section className="mb-6">
+      <h2 className="mb-2 text-base font-semibold text-gray-900">{title}</h2>
+      <div className="text-sm text-gray-700">{children}</div>
+    </section>
+  );
+}
+
+interface RowProps {
+  label: string;
+  items: string;
+  timing: string;
+}
+
+function Row({ label, items, timing }: RowProps) {
+  return (
+    <tr className="border-b border-gray-200">
+      <td className="px-2 py-2 align-top font-medium">{label}</td>
+      <td className="px-2 py-2 align-top">{items}</td>
+      <td className="px-2 py-2 align-top text-gray-600">{timing}</td>
+    </tr>
+  );
+}
+
+interface SimpleRowProps {
+  vendor: string;
+  task: string;
+}
+
+function SimpleRow({ vendor, task }: SimpleRowProps) {
+  return (
+    <tr className="border-b border-gray-200">
+      <td className="px-2 py-2 align-top font-medium">{vendor}</td>
+      <td className="px-2 py-2 align-top">{task}</td>
+    </tr>
+  );
+}

--- a/src/components/TermsView.tsx
+++ b/src/components/TermsView.tsx
@@ -1,0 +1,159 @@
+import { useEffect } from 'react';
+import { BUSINESS_INFO, SERVICE_INFO } from '@/config/business';
+import { Footer } from '@/components/Footer';
+
+export function TermsView() {
+  useEffect(() => {
+    if (window.location.hash) {
+      const el = document.getElementById(window.location.hash.slice(1));
+      if (el) el.scrollIntoView({ behavior: 'instant', block: 'start' });
+    }
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+      <article className="mx-auto max-w-3xl px-4 py-10 text-sm leading-relaxed text-gray-800">
+        <h1 className="mb-2 text-2xl font-semibold text-gray-900">이용약관</h1>
+        <p className="mb-8 text-xs text-gray-500">시행일: {SERVICE_INFO.effectiveDate}</p>
+
+        <Section title="제1조 (목적)">
+          이 약관은 {BUSINESS_INFO.companyName}(이하 "회사")가 제공하는 {SERVICE_INFO.serviceName}(이하 "서비스")의
+          이용과 관련하여 회사와 이용자 간의 권리, 의무 및 책임사항, 기타 필요한 사항을 규정함을 목적으로 합니다.
+        </Section>
+
+        <Section title="제2조 (정의)">
+          <ol className="list-decimal space-y-1 pl-5">
+            <li>"서비스"란 회사가 제공하는 자동 근무표 생성 및 검증 도구를 의미합니다.</li>
+            <li>"이용자"란 본 약관에 동의하고 서비스를 이용하는 회원 및 비회원을 말합니다.</li>
+            <li>"회원"이란 Google 계정을 통해 가입한 이용자를 말합니다.</li>
+            <li>"유료 상품"이란 데이 패스(Day Pass) 및 연간 구독(Annual)을 말합니다.</li>
+            <li>"자동결제"란 회원이 사전에 등록한 결제수단으로 정기적으로 청구되는 결제 방식을 말합니다.</li>
+          </ol>
+        </Section>
+
+        <Section title="제3조 (약관의 효력 및 변경)">
+          <ol className="list-decimal space-y-1 pl-5">
+            <li>본 약관은 서비스 화면에 게시함으로써 효력이 발생합니다.</li>
+            <li>회사는 관련 법령을 위배하지 않는 범위에서 본 약관을 변경할 수 있으며, 변경 시 적용일자 7일 전부터
+              공지합니다. 다만 회원에게 불리한 변경은 30일 전부터 공지합니다.</li>
+            <li>회원이 변경된 약관에 동의하지 않는 경우 이용계약을 해지할 수 있습니다.</li>
+          </ol>
+        </Section>
+
+        <Section title="제4조 (서비스의 제공 및 이용)">
+          <ol className="list-decimal space-y-1 pl-5">
+            <li>회사는 회원에게 다음 각 호의 서비스를 제공합니다.
+              <ul className="mt-1 list-disc space-y-0.5 pl-5">
+                <li>무료 회원: 매월 자동 스케줄 생성 3회</li>
+                <li>데이 패스: 결제 후 24시간 동안 자동 스케줄 무제한 생성</li>
+                <li>연간 구독: 월 단위 자동결제, 1년 단위 갱신, 자동 스케줄 무제한 생성</li>
+              </ul>
+            </li>
+            <li>서비스 이용은 회사의 업무상 또는 기술상 특별한 지장이 없는 한 연중무휴, 1일 24시간을 원칙으로 합니다.</li>
+            <li>회사는 정기점검, 시스템 업그레이드, 장애 등 부득이한 경우 서비스의 전부 또는 일부를 일시 중단할 수 있습니다.</li>
+          </ol>
+        </Section>
+
+        <Section title="제5조 (요금 및 결제)">
+          <ol className="list-decimal space-y-1 pl-5">
+            <li>유료 상품의 요금은 다음과 같습니다.
+              <ul className="mt-1 list-disc space-y-0.5 pl-5">
+                <li>데이 패스: 3,000원 (1회 결제, 24시간 사용)</li>
+                <li>연간 구독: 월 3,000원 (자동결제, 1년 단위 갱신, 최대 12개월)</li>
+              </ul>
+            </li>
+            <li>결제수단은 신용카드, 계좌이체, 간편결제로 한정합니다. 가상계좌는 지원하지 않습니다.</li>
+            <li>결제는 (주)토스페이먼츠가 제공하는 결제대행 서비스를 통해 처리됩니다.</li>
+            <li>회사는 회원의 결제정보를 직접 저장하지 않으며, 결제대행사가 안전하게 보관·관리합니다.</li>
+          </ol>
+        </Section>
+
+        <Section title="제6조 (자동결제)">
+          <ol className="list-decimal space-y-1 pl-5">
+            <li>연간 구독은 자동결제 방식으로 운영되며, 회원의 명시적 동의 후 등록됩니다.</li>
+            <li>자동결제는 매월 같은 일자에 등록된 결제수단으로 청구됩니다.</li>
+            <li>회원은 언제든지 마이페이지에서 자동결제를 해지할 수 있으며, 해지 시점부터 다음 결제일이 도래하지 않습니다.</li>
+            <li>결제 실패 시 회사는 이메일로 안내하며, 일정 기간 내 재시도합니다. 재시도 후에도 결제가 이루어지지 않는 경우 구독은 자동 만료됩니다.</li>
+          </ol>
+        </Section>
+
+        <Section title="제7조 (청약철회 및 환불)" id="refund">
+          <ol className="list-decimal space-y-1 pl-5">
+            <li><strong>디지털 콘텐츠 특례</strong>: 본 서비스는 「전자상거래 등에서의 소비자보호에 관한 법률」 제17조 제2항 제5호에 따른
+              디지털 콘텐츠로, 이용 시작 시점부터 청약철회가 제한됩니다.</li>
+            <li><strong>무료 시험 사용</strong>: 회사는 매월 3회의 무료 자동 생성을 제공하여 이용자가 결제 전 서비스를 충분히
+              체험할 수 있도록 합니다.</li>
+            <li>데이 패스: 결제 후 단 한 번도 이용하지 않은 경우에 한해 결제일로부터 7일 이내 환불 요청 가능합니다.</li>
+            <li>연간 구독: 다음 결제일 전 해지 시 추가 청구가 이루어지지 않으며, 이미 결제된 월분은 환불되지 않습니다.</li>
+            <li>환불 요청은 이메일({BUSINESS_INFO.email})로 접수하며, 적법한 사유가 인정되는 경우 영업일 기준 3일 이내 처리됩니다.</li>
+            <li>회사의 귀책사유로 서비스 이용이 불가한 경우 잔여 기간을 일할 계산하여 환불합니다.</li>
+          </ol>
+        </Section>
+
+        <Section title="제8조 (회원의 의무)">
+          <ol className="list-decimal space-y-1 pl-5">
+            <li>회원은 본 약관 및 관련 법령을 준수해야 합니다.</li>
+            <li>회원은 자신의 계정을 제3자에게 양도, 대여할 수 없습니다.</li>
+            <li>회원은 서비스를 이용하여 다음 행위를 해서는 안 됩니다.
+              <ul className="mt-1 list-disc space-y-0.5 pl-5">
+                <li>타인의 정보 도용</li>
+                <li>서비스의 운영을 방해하는 행위</li>
+                <li>서비스를 무단으로 복제, 재판매하는 행위</li>
+                <li>관련 법령에 위배되는 행위</li>
+              </ul>
+            </li>
+          </ol>
+        </Section>
+
+        <Section title="제9조 (책임 제한)">
+          <ol className="list-decimal space-y-1 pl-5">
+            <li>회사는 천재지변, 전쟁, 기간통신사업자의 서비스 중지 등 불가항력적 사유로 서비스를 제공할 수 없는 경우
+              책임이 면제됩니다.</li>
+            <li>본 서비스가 생성하는 근무표는 입력된 제약조건을 만족하는 후보안이며, 최종 결정과 운영 책임은 이용자에게 있습니다.</li>
+            <li>회사는 회원이 서비스를 이용하여 얻은 정보로 인한 손해에 대하여 책임을 지지 않습니다.</li>
+          </ol>
+        </Section>
+
+        <Section title="제10조 (분쟁해결)">
+          <ol className="list-decimal space-y-1 pl-5">
+            <li>본 약관은 대한민국 법령에 따라 규율됩니다.</li>
+            <li>서비스 이용으로 발생한 분쟁은 회사 본점 소재지 관할 법원을 제1심 관할 법원으로 합니다.</li>
+          </ol>
+        </Section>
+
+        <p className="mt-10 border-t border-gray-200 pt-4 text-xs text-gray-500">
+          부칙: 본 약관은 {SERVICE_INFO.effectiveDate}부터 시행됩니다.
+        </p>
+      </article>
+      <Footer />
+    </div>
+  );
+}
+
+function Header() {
+  return (
+    <header className="border-b border-gray-200 bg-white">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
+        <a href="/" className="text-sm font-medium text-gray-800 hover:text-gray-900">
+          ← {SERVICE_INFO.serviceName}
+        </a>
+      </div>
+    </header>
+  );
+}
+
+interface SectionProps {
+  title: string;
+  id?: string;
+  children: React.ReactNode;
+}
+
+function Section({ title, id, children }: SectionProps) {
+  return (
+    <section id={id} className="mb-6 scroll-mt-16">
+      <h2 className="mb-2 text-base font-semibold text-gray-900">{title}</h2>
+      <div className="text-sm text-gray-700">{children}</div>
+    </section>
+  );
+}

--- a/src/components/UpgradePrompt.tsx
+++ b/src/components/UpgradePrompt.tsx
@@ -1,0 +1,95 @@
+/**
+ * Upgrade dialog shown when free generation limit (3/month) is reached.
+ * Presents Day Pass vs Annual subscription comparison.
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface UpgradePromptProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onUpgrade: (type: 'daypass' | 'annual') => void;
+}
+
+export function UpgradePrompt({
+  open,
+  onOpenChange,
+  onUpgrade,
+}: UpgradePromptProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>무료 생성 횟수 소진</DialogTitle>
+          <DialogDescription>
+            이번 달 무료 생성 횟수(3회)를 모두 사용했습니다.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="py-2">
+          {/* Comparison table */}
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="border-b border-gray-200">
+                <th className="py-2 text-left font-medium text-muted-foreground" />
+                <th className="py-2 text-center font-medium">Day Pass</th>
+                <th className="py-2 text-center font-medium text-blue-600">
+                  Annual
+                  <span className="ml-1 text-[10px] bg-blue-100 text-blue-700 px-1.5 py-0.5 rounded-full font-normal">
+                    추천
+                  </span>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="text-center">
+              <tr className="border-b border-gray-100">
+                <td className="py-2.5 text-left text-muted-foreground">가격</td>
+                <td className="py-2.5">3,000원/1회</td>
+                <td className="py-2.5 font-medium">3,000원/월</td>
+              </tr>
+              <tr className="border-b border-gray-100">
+                <td className="py-2.5 text-left text-muted-foreground">기간</td>
+                <td className="py-2.5">24시간</td>
+                <td className="py-2.5">무제한</td>
+              </tr>
+              <tr className="border-b border-gray-100">
+                <td className="py-2.5 text-left text-muted-foreground">자동 갱신</td>
+                <td className="py-2.5">X</td>
+                <td className="py-2.5">O</td>
+              </tr>
+              <tr>
+                <td className="py-2.5 text-left text-muted-foreground">추천</td>
+                <td className="py-2.5 text-xs text-muted-foreground">일회성 사용</td>
+                <td className="py-2.5 text-xs text-blue-600">매달 사용</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex flex-col sm:flex-row gap-2 pt-2">
+          <button
+            type="button"
+            onClick={() => onUpgrade('daypass')}
+            className="flex-1 px-4 py-2.5 text-sm font-medium border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
+          >
+            데이 패스 구매
+          </button>
+          <button
+            type="button"
+            onClick={() => onUpgrade('annual')}
+            className="flex-1 px-4 py-2.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 transition-colors"
+          >
+            연간 구독 (추천)
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,0 +1,122 @@
+/**
+ * User avatar dropdown menu for authenticated users.
+ * Shows plan badge, subscription management, and sign-out.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import type { AuthUser } from '@/types/auth';
+import { useAuth } from '@/contexts/AuthContext';
+
+interface UserMenuProps {
+  user: AuthUser;
+}
+
+const PLAN_LABELS: Record<string, string> = {
+  free: '무료',
+  daypass: 'Day Pass',
+  annual: 'Annual',
+};
+
+export function UserMenu({ user }: UserMenuProps) {
+  const { signOut } = useAuth();
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const initial = user.name.charAt(0).toUpperCase();
+  const planLabel = PLAN_LABELS[user.plan] ?? user.plan;
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [open]);
+
+  const handleSubscriptionManage = useCallback(() => {
+    setOpen(false);
+    toast.info('준비 중');
+  }, []);
+
+  const handleSignOut = useCallback(() => {
+    setOpen(false);
+    signOut();
+    toast.success('로그아웃되었습니다.');
+  }, [signOut]);
+
+  return (
+    <div ref={menuRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex items-center gap-2 px-2 py-1 rounded-md hover:bg-gray-100 transition-colors"
+        aria-expanded={open}
+        aria-haspopup="true"
+      >
+        <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-blue-600 text-white text-xs font-medium">
+          {initial}
+        </span>
+        <span className="text-sm text-gray-700 hidden sm:inline">
+          {user.name}
+        </span>
+      </button>
+
+      {open && (
+        <div className="absolute right-0 mt-1 w-48 bg-white border border-gray-200 rounded-md shadow-lg z-30 py-1">
+          {/* Plan badge */}
+          <div className="px-3 py-2 border-b border-gray-100">
+            <span className="text-xs text-muted-foreground">현재 플랜</span>
+            <div className="mt-0.5">
+              <span
+                className={
+                  user.plan === 'annual'
+                    ? 'text-xs font-medium px-2 py-0.5 rounded-full bg-blue-100 text-blue-700'
+                    : user.plan === 'daypass'
+                      ? 'text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-700'
+                      : 'text-xs font-medium px-2 py-0.5 rounded-full bg-gray-100 text-gray-600'
+                }
+              >
+                {planLabel}
+              </span>
+            </div>
+          </div>
+
+          {/* Menu items */}
+          <button
+            type="button"
+            onClick={handleSubscriptionManage}
+            className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+          >
+            구독 관리
+          </button>
+          <button
+            type="button"
+            onClick={handleSignOut}
+            className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+          >
+            로그아웃
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/config/business.ts
+++ b/src/config/business.ts
@@ -7,30 +7,31 @@
 
 export const BUSINESS_INFO = {
   // 상호명 (Business Name)
-  companyName: 'PLACEHOLDER_상호명',
+  companyName: '루트프로토',
 
   // 대표자명 (Representative)
-  representative: 'PLACEHOLDER_대표자명',
+  representative: '최종원',
 
   // 사업자등록번호 (Business Registration Number, 10 digits with hyphens)
-  businessRegistrationNumber: 'PLACEHOLDER_000-00-00000',
+  businessRegistrationNumber: '790-53-01184',
 
   // 통신판매업 신고번호 (Mail-Order Sales Registration Number)
-  mailOrderRegistrationNumber: 'PLACEHOLDER_제0000-서울XX구-0000호',
+  // TODO: 통신판매업 신고 후 신고번호 기재 (예: 제2026-부산기장-0000호)
+  mailOrderRegistrationNumber: 'PLACEHOLDER_통신판매업_신고번호',
 
   // 사업장 주소 (Business Address)
-  address: 'PLACEHOLDER_서울특별시 XX구 XX로 00 (00동, 00빌딩 0층)',
+  address: '부산광역시 기장군 기장읍 읍내로 56, 3층 (두원인테리어)',
 
-  // 유선 전화번호 (Landline)
-  phone: 'PLACEHOLDER_02-0000-0000',
+  // 연락처 (대표 번호 — 유선·휴대 통일)
+  phone: '010-8514-0289',
 
-  // 대표 이메일 (Customer Service Email)
-  email: 'support@connects.im',
+  // 대표 이메일 (Customer Service + Privacy Officer 겸용)
+  email: 'choi@rootproto.com',
 
   // 개인정보 보호책임자 (Privacy Officer)
   privacyOfficer: {
-    name: 'PLACEHOLDER_보호책임자명',
-    email: 'privacy@connects.im',
+    name: '최종원',
+    email: 'choi@rootproto.com',
   },
 
   // 호스팅 (Hosting Provider)

--- a/src/config/business.ts
+++ b/src/config/business.ts
@@ -1,0 +1,44 @@
+/**
+ * Business information for legal compliance and TossPayments review.
+ *
+ * 배포 전 모든 PLACEHOLDER 값을 실제 사업자 정보로 교체할 것.
+ * 누락 시 TossPayments 카드사 심사([3]-2)에서 제외될 수 있음.
+ */
+
+export const BUSINESS_INFO = {
+  // 상호명 (Business Name)
+  companyName: 'PLACEHOLDER_상호명',
+
+  // 대표자명 (Representative)
+  representative: 'PLACEHOLDER_대표자명',
+
+  // 사업자등록번호 (Business Registration Number, 10 digits with hyphens)
+  businessRegistrationNumber: 'PLACEHOLDER_000-00-00000',
+
+  // 통신판매업 신고번호 (Mail-Order Sales Registration Number)
+  mailOrderRegistrationNumber: 'PLACEHOLDER_제0000-서울XX구-0000호',
+
+  // 사업장 주소 (Business Address)
+  address: 'PLACEHOLDER_서울특별시 XX구 XX로 00 (00동, 00빌딩 0층)',
+
+  // 유선 전화번호 (Landline)
+  phone: 'PLACEHOLDER_02-0000-0000',
+
+  // 대표 이메일 (Customer Service Email)
+  email: 'support@connects.im',
+
+  // 개인정보 보호책임자 (Privacy Officer)
+  privacyOfficer: {
+    name: 'PLACEHOLDER_보호책임자명',
+    email: 'privacy@connects.im',
+  },
+
+  // 호스팅 (Hosting Provider)
+  hosting: 'GitHub Pages (Microsoft) / Amazon Web Services',
+} as const;
+
+export const SERVICE_INFO = {
+  serviceName: '교대근무 자동 스케줄러',
+  serviceUrl: 'https://shift-schedule.connects.im',
+  effectiveDate: '2026-04-26',
+} as const;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,127 @@
+/**
+ * Authentication context provider.
+ *
+ * Manages JWT tokens (1h access + 7d refresh) in localStorage.
+ * Anonymous browsing allowed — auth gates only auto-generation.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+import type { AuthUser } from '@/types/auth';
+import {
+  clearTokens,
+  getCurrentUser,
+  getStoredAccessToken,
+  getStoredRefreshToken,
+  getValidAccessToken,
+  loginWithGoogle,
+  storeTokens,
+} from '@/services/authApi';
+
+interface AuthContextValue {
+  /** Current authenticated user, or null if not logged in. */
+  user: AuthUser | null;
+  /** Whether initial auth check is in progress. */
+  isLoading: boolean;
+  /** Whether user is authenticated. */
+  isAuthenticated: boolean;
+  /** Sign in with Google ID token. */
+  signIn: (idToken: string) => Promise<void>;
+  /** Sign out and clear tokens. */
+  signOut: () => void;
+  /** Refresh user data from server (e.g., after plan upgrade). */
+  refreshUser: () => Promise<void>;
+  /** Get a valid access token for API calls. Returns null if not authenticated. */
+  getAccessToken: () => Promise<string | null>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Check existing session on mount
+  useEffect(() => {
+    const checkSession = async () => {
+      const accessToken = getStoredAccessToken();
+      const refreshToken = getStoredRefreshToken();
+
+      if (!accessToken && !refreshToken) {
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const token = await getValidAccessToken();
+        if (token) {
+          const { user: userData } = await getCurrentUser(token);
+          setUser(userData);
+        }
+      } catch {
+        clearTokens();
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    checkSession();
+  }, []);
+
+  const signIn = useCallback(async (idToken: string) => {
+    const response = await loginWithGoogle(idToken);
+    storeTokens(response.accessToken, response.refreshToken);
+    setUser(response.user);
+  }, []);
+
+  const signOut = useCallback(() => {
+    clearTokens();
+    setUser(null);
+  }, []);
+
+  const refreshUser = useCallback(async () => {
+    const token = await getValidAccessToken();
+    if (token) {
+      const { user: userData } = await getCurrentUser(token);
+      setUser(userData);
+    }
+  }, []);
+
+  const getAccessToken = useCallback(async () => {
+    return getValidAccessToken();
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user,
+      isLoading,
+      isAuthenticated: user !== null,
+      signIn,
+      signOut,
+      refreshUser,
+      getAccessToken,
+    }),
+    [user, isLoading, signIn, signOut, refreshUser, getAccessToken],
+  );
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -10,6 +10,7 @@ import type {
   GenerationStatus,
   FeasibilityCheckResponse,
 } from '@/types';
+import { GenerationLimitError } from '@/types/auth';
 import { checkFeasibility, getDefaultConfig } from '@/solver/feasibilityChecker';
 import { calculateScheduleCompleteness } from '@/utils/shiftUtils';
 import { getEligibleShifts } from '@/utils/staffUtils';
@@ -562,6 +563,10 @@ export function useSchedule() {
       }
     } catch (error) {
       setGenerationStatus('error');
+      // Re-throw GenerationLimitError so App-level handler can show UpgradePrompt
+      if (error instanceof GenerationLimitError) {
+        throw error;
+      }
       const message = error instanceof Error ? error.message : '알 수 없는 오류';
       toast.error(`API 오류: ${message}`);
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { AuthProvider } from '@/contexts/AuthContext'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </StrictMode>,
 )

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -1,0 +1,110 @@
+/**
+ * Auth API client for shift-schedule monetization.
+ */
+
+import type {
+  AuthResponse,
+  AuthUser,
+  RefreshResponse,
+} from '@/types/auth';
+
+const API_BASE = import.meta.env.VITE_API_URL ?? '';
+
+async function authFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  if (!API_BASE) {
+    throw new Error('VITE_API_URL not configured');
+  }
+  const response = await fetch(`${API_BASE}${path}`, {
+    headers: { 'Content-Type': 'application/json', ...options.headers },
+    ...options,
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: { message: response.statusText } }));
+    throw new Error(error.error?.message ?? `API error: ${response.status}`);
+  }
+  return response.json();
+}
+
+/** Exchange Google ID token for app JWT tokens + user info. */
+export async function loginWithGoogle(idToken: string): Promise<AuthResponse> {
+  return authFetch<AuthResponse>('/auth/google', {
+    method: 'POST',
+    body: JSON.stringify({ idToken }),
+  });
+}
+
+/** Refresh access token using refresh token. */
+export async function refreshAccessToken(refreshToken: string): Promise<RefreshResponse> {
+  return authFetch<RefreshResponse>('/auth/refresh', {
+    method: 'POST',
+    body: JSON.stringify({ refreshToken }),
+  });
+}
+
+/** Get current user info (also performs payment reconciliation). */
+export async function getCurrentUser(accessToken: string): Promise<{ user: AuthUser }> {
+  return authFetch<{ user: AuthUser }>('/auth/me', {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+}
+
+// --- Token Storage (localStorage) ---
+
+const ACCESS_TOKEN_KEY = 'shift-schedule-access-token';
+const REFRESH_TOKEN_KEY = 'shift-schedule-refresh-token';
+
+export function getStoredAccessToken(): string | null {
+  return localStorage.getItem(ACCESS_TOKEN_KEY);
+}
+
+export function getStoredRefreshToken(): string | null {
+  return localStorage.getItem(REFRESH_TOKEN_KEY);
+}
+
+export function storeTokens(accessToken: string, refreshToken: string): void {
+  localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+  localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+}
+
+export function clearTokens(): void {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+}
+
+/** Check if access token is expired by decoding JWT payload. */
+export function isTokenExpired(token: string): boolean {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return payload.exp * 1000 < Date.now();
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Get a valid access token, refreshing if needed.
+ * Returns null if no valid session exists.
+ */
+export async function getValidAccessToken(): Promise<string | null> {
+  const accessToken = getStoredAccessToken();
+  if (accessToken && !isTokenExpired(accessToken)) {
+    return accessToken;
+  }
+
+  // Try refresh
+  const refreshToken = getStoredRefreshToken();
+  if (!refreshToken || isTokenExpired(refreshToken)) {
+    clearTokens();
+    return null;
+  }
+
+  try {
+    const { accessToken: newToken } = await refreshAccessToken(refreshToken);
+    localStorage.setItem(ACCESS_TOKEN_KEY, newToken);
+    return newToken;
+  } catch {
+    clearTokens();
+    return null;
+  }
+}

--- a/src/services/solverApi.ts
+++ b/src/services/solverApi.ts
@@ -4,22 +4,74 @@ import type {
   FeasibilityCheckRequest,
   FeasibilityCheckResponse,
 } from '@/types/api';
+import { GenerationLimitError } from '@/types/auth';
+import type { GenerationLimitInfo } from '@/types/auth';
+import { getValidAccessToken, clearTokens } from '@/services/authApi';
 
 const API_BASE = import.meta.env.VITE_SOLVER_API_URL ?? '';
+
+/** Last known remaining generation count from X-Generation-Remaining header. */
+let _lastRemainingCount: number | null = null;
+
+export function getLastRemainingCount(): number | null {
+  return _lastRemainingCount;
+}
+
+async function authenticatedFetch(url: string, options: RequestInit): Promise<Response> {
+  const token = await getValidAccessToken();
+  if (!token) {
+    throw new Error('Authentication required');
+  }
+
+  const headers = new Headers(options.headers);
+  headers.set('Authorization', `Bearer ${token}`);
+  headers.set('Content-Type', 'application/json');
+
+  let response = await fetch(url, { ...options, headers });
+
+  // Handle 401: try refresh once, then retry
+  if (response.status === 401) {
+    // Token might have just expired — getValidAccessToken should have refreshed,
+    // but if the server rejected it, clear and signal auth needed
+    clearTokens();
+    throw new Error('Authentication required');
+  }
+
+  // Handle 403: generation limit
+  if (response.status === 403) {
+    const errorBody = await response.json().catch(() => null);
+    if (errorBody?.error?.code === 'GENERATION_LIMIT') {
+      const info: GenerationLimitInfo = {
+        remaining: errorBody.remaining ?? 0,
+        limit: errorBody.limit ?? 3,
+        plans: errorBody.plans ?? [],
+      };
+      _lastRemainingCount = 0;
+      throw new GenerationLimitError(info);
+    }
+  }
+
+  return response;
+}
 
 export async function generateSchedule(request: GenerateRequest): Promise<GenerateResponse> {
   if (!API_BASE) {
     throw new Error('VITE_SOLVER_API_URL not configured');
   }
 
-  const response = await fetch(`${API_BASE}/generate`, {
+  const response = await authenticatedFetch(`${API_BASE}/generate`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(request),
   });
 
   if (!response.ok) {
     throw new Error(`API error: ${response.status}`);
+  }
+
+  // Read remaining generation count from header
+  const remaining = response.headers.get('X-Generation-Remaining');
+  if (remaining !== null) {
+    _lastRemainingCount = parseInt(remaining, 10);
   }
 
   return response.json();
@@ -32,6 +84,7 @@ export async function checkFeasibilityApi(
     throw new Error('VITE_SOLVER_API_URL not configured');
   }
 
+  // Feasibility check does NOT require auth
   const response = await fetch(`${API_BASE}/check-feasibility`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,105 @@
+/**
+ * Authentication and subscription types for shift-schedule monetization.
+ */
+
+// --- User & Auth ---
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  name: string;
+  plan: Plan;
+  generationCount: number;
+  generationMonth: string;
+  subscriptionStatus: SubscriptionStatus | null;
+  subscriptionEndDate: string | null;
+  dayPassExpiry: string | null;
+}
+
+export type Plan = 'free' | 'daypass' | 'annual';
+
+export type SubscriptionStatus = 'active' | 'cancelled' | 'expired';
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface AuthResponse {
+  accessToken: string;
+  refreshToken: string;
+  user: AuthUser;
+}
+
+export interface RefreshResponse {
+  accessToken: string;
+}
+
+// --- Payment ---
+
+export interface PaymentConfirmRequest {
+  paymentKey: string;
+  orderId: string;
+  productType: 'daypass' | 'annual';
+}
+
+export interface BillingIssueRequest {
+  authKey: string;
+  customerKey: string;
+}
+
+export interface PaymentConfirmResponse {
+  success: boolean;
+  payment: {
+    paymentKey: string;
+    orderId: string;
+    amount: number;
+    type: string;
+    status: string;
+  };
+  user: AuthUser;
+}
+
+// --- Generation Limit ---
+
+export interface GenerationLimitInfo {
+  remaining: number;
+  limit: number;
+  plans: PlanOption[];
+}
+
+export interface PlanOption {
+  type: 'daypass' | 'annual';
+  price: number;
+  currency: string;
+  duration?: string;
+  period?: string;
+}
+
+// --- API Error ---
+
+export interface ApiErrorResponse {
+  error: {
+    code: string;
+    message: string;
+  };
+  remaining?: number;
+  limit?: number;
+  plans?: PlanOption[];
+}
+
+// --- Custom Error ---
+
+export class GenerationLimitError extends Error {
+  readonly remaining: number;
+  readonly limit: number;
+  readonly plans: PlanOption[];
+
+  constructor(info: GenerationLimitInfo) {
+    super('Monthly generation limit reached');
+    this.name = 'GenerationLimitError';
+    this.remaining = info.remaining;
+    this.limit = info.limit;
+    this.plans = info.plans;
+  }
+}


### PR DESCRIPTION
## Summary
- Google OAuth 인증 + JWT 토큰 관리 (1h access + 7d refresh)
- 익명 브라우징 허용, 자동 생성만 인증 게이트
- 무료 3회/월 생성 제한 + Day Pass/Annual 비교 UpgradePrompt
- **법적 준수** (#22): 사이트 푸터 (사업자정보 + 통신판매업 신고번호), `/terms` 이용약관 (디지털 콘텐츠 청약철회 특례, 환불정책 #refund), `/privacy` 개인정보처리방침
- **가격 페이지** (#24): `/pricing` (Day Pass 3,000원 + Annual 월 3,000원/최대 12개월) + 결제수단 안내 (가상계좌 미지원)
- pathname 분기 라우팅 + GitHub Pages SPA fallback (`public/404.html` + `index.html` decoder)

## TossPayments MID 신청 prerequisite (deadline 2026-05-22)
- [3]-2 푸터 사업자정보: 충족 (배포 전 `src/config/business.ts` placeholder 교체 필요)
- [1]-1① 결제 페이지 URL: `/pricing` 충족
- [3]-1 결제 가능한 상품 1개 이상 노출: 충족
- [1]-1② 환불정책 URL: `/terms#refund` 충족
- [1]-2 서비스 제공기간 명시: 충족
- 가상계좌 제거 결정 반영 (≤6mo 정책 충돌 회피)

## 배포 전 체크리스트
- [ ] `src/config/business.ts` placeholder를 실제 사업자정보로 교체
- [ ] `npm run build` 성공 확인
- [ ] Google Sign-In 다이얼로그 렌더링 확인
- [ ] 익명 브라우징 가능 확인
- [ ] `/pricing`, `/terms`, `/privacy` 정적 URL 접근 확인 (GitHub Pages 404 fallback 동작)
- [ ] 자동 생성 시 LoginPrompt → 403 GENERATION_LIMIT → UpgradePrompt 흐름 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
