### PR TITLE
fix(useLocalStorage): deepMerge가 저장본 전용 키를 보존하도록 합집합 순회

### DIFF
--- a/src/hooks/__tests__/useLocalStorage.test.ts
+++ b/src/hooks/__tests__/useLocalStorage.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useLocalStorage } from '../useLocalStorage';
+
+/**
+ * jsdom in this config exposes a bare `localStorage` object without Storage methods,
+ * so we install a minimal in-memory Storage mock for the read/write paths the hook uses.
+ */
+function installLocalStorageMock() {
+  const store = new Map<string, string>();
+  const mock: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    removeItem: (k: string) => void store.delete(k),
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+  };
+  Object.defineProperty(window, 'localStorage', { value: mock, configurable: true });
+  Object.defineProperty(globalThis, 'localStorage', { value: mock, configurable: true });
+}
+
+/**
+ * Regression coverage for the deep-merge restore path.
+ *
+ * Bug: on reload, `useLocalStorage` restores by deep-merging the stored value into the
+ * default (schema) value. The merge previously iterated only the default's keys, so any
+ * key present only in storage — `cellExclusions`, `staffJuhuDays`, `requiredNights`, all
+ * dynamic-keyed — was silently dropped. These tests pin the source-only-key preservation
+ * so the data loss cannot return unnoticed.
+ */
+describe('useLocalStorage restore (deep merge)', () => {
+  const KEY = 'test-key';
+
+  beforeEach(() => {
+    installLocalStorageMock();
+  });
+
+  function seed(value: unknown) {
+    localStorage.setItem(KEY, JSON.stringify(value));
+  }
+
+  it('preserves a top-level key that exists only in storage', () => {
+    // default has no `extra`; storage does — it must survive restore
+    seed({ a: 2, extra: 'kept' });
+    const { result } = renderHook(() => useLocalStorage(KEY, { a: 1 }));
+    expect(result.current[0]).toEqual({ a: 2, extra: 'kept' });
+  });
+
+  it('preserves dynamic record keys nested under an empty-object default (the cellExclusions case)', () => {
+    // This is the case adding `cellExclusions: {}` to the default could NOT fix:
+    // the recursion would re-strip the dynamic keys one level down.
+    seed({ cellExclusions: { 'staff1-2025-01-06': ['N', 'D'] } });
+    const { result } = renderHook(() =>
+      useLocalStorage<{ cellExclusions: Record<string, string[]> }>(KEY, {
+        cellExclusions: {},
+      })
+    );
+    expect(result.current[0].cellExclusions).toEqual({
+      'staff1-2025-01-06': ['N', 'D'],
+    });
+  });
+
+  it('restores a realistic Schedule shape without losing cellExclusions / staffJuhuDays', () => {
+    const stored = {
+      id: 'sched-1',
+      name: '근무표',
+      startDate: '2025-01-06',
+      assignments: [{ staffId: 's1', date: '2025-01-06', shift: 'N', isLocked: true }],
+      cellExclusions: { 's1-2025-01-07': ['N'] },
+      staffJuhuDays: [{ staffId: 's1', juhuDay: 3 }],
+    };
+    seed(stored);
+    // default schema mirrors getDefaultSchedule(): no cellExclusions / staffJuhuDays key
+    const { result } = renderHook(() =>
+      useLocalStorage(KEY, {
+        id: 'default',
+        name: '근무표',
+        startDate: '2025-01-01',
+        assignments: [],
+      })
+    );
+    expect(result.current[0]).toEqual(stored);
+  });
+
+  it('still preserves a default-only key (forward-compat for newly added schema fields)', () => {
+    seed({ a: 2 });
+    const { result } = renderHook(() =>
+      useLocalStorage(KEY, { a: 1, newField: 'default' })
+    );
+    expect(result.current[0]).toEqual({ a: 2, newField: 'default' });
+  });
+
+  it('replaces arrays wholesale rather than merging element-wise', () => {
+    seed({ items: [1, 2, 3] });
+    const { result } = renderHook(() =>
+      useLocalStorage<{ items: number[] }>(KEY, { items: [] })
+    );
+    expect(result.current[0].items).toEqual([1, 2, 3]);
+  });
+
+  it('lets stored scalar values override the default', () => {
+    seed({ a: 'stored' });
+    const { result } = renderHook(() => useLocalStorage(KEY, { a: 'default' }));
+    expect(result.current[0].a).toBe('stored');
+  });
+});

--- a/src/hooks/__tests__/useLocalStorage.test.ts
+++ b/src/hooks/__tests__/useLocalStorage.test.ts
@@ -106,4 +106,17 @@ describe('useLocalStorage restore (deep merge)', () => {
     const { result } = renderHook(() => useLocalStorage(KEY, { a: 'default' }));
     expect(result.current[0].a).toBe('stored');
   });
+
+  it('does not let a tampered __proto__ key pollute the restored object prototype', () => {
+    // JSON.parse makes "__proto__" an own-enumerable key; iterating source keys must not
+    // route it through result[key] = ... and reassign the prototype.
+    localStorage.setItem(KEY, '{"a":2,"__proto__":{"polluted":true}}');
+    const { result } = renderHook(() => useLocalStorage(KEY, { a: 1 }));
+    const restored = result.current[0] as Record<string, unknown>;
+    expect(restored.a).toBe(2);
+    expect('polluted' in restored).toBe(false);
+    expect(Object.getPrototypeOf(restored)).toBe(Object.prototype);
+    // global prototype must remain clean as well
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
 });

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -22,6 +22,12 @@ function deepMerge<T>(target: T, source: Partial<T>): T {
     ...Object.keys(source as object),
   ]);
   for (const key of allKeys) {
+    // Skip prototype-polluting keys: now that source keys are iterated, a tampered/corrupt
+    // stored value could carry an own `__proto__`/`constructor` key (JSON.parse makes these
+    // own-enumerable) and reassign the restored object's prototype via result[key] = ...
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue;
+    }
     if (key in source) {
       const targetVal = (target as Record<string, unknown>)[key];
       const sourceVal = (source as Record<string, unknown>)[key];

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -2,7 +2,11 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 
 /**
  * Deep merge two objects. Values from `source` override `target`.
- * New keys in `target` (not in `source`) are preserved.
+ * New keys in `target` (not in `source`) are preserved (forward-compat: new schema fields).
+ * Keys only in `source` (not in `target`) are also preserved — e.g. dynamic-keyed records
+ * like `cellExclusions` / `requiredNights` whose keys never appear in the static default.
+ * Legacy field removal is handled by version-gated migration (see migrateStorageIfNeeded),
+ * not by this merge, so preserving source-only keys does not resurrect deprecated fields.
  */
 function deepMerge<T>(target: T, source: Partial<T>): T {
   if (target === null || typeof target !== 'object' || Array.isArray(target)) {
@@ -13,7 +17,11 @@ function deepMerge<T>(target: T, source: Partial<T>): T {
   }
 
   const result = { ...target } as Record<string, unknown>;
-  for (const key of Object.keys(target as object)) {
+  const allKeys = new Set([
+    ...Object.keys(target as object),
+    ...Object.keys(source as object),
+  ]);
+  for (const key of allKeys) {
     if (key in source) {
       const targetVal = (target as Record<string, unknown>)[key];
       const sourceVal = (source as Record<string, unknown>)[key];


### PR DESCRIPTION
## 문제

새로고침 후 셀 **고정의 X 표시(`cellExclusions`)**가 사라지는 버그. 추적 결과 같은 원인으로 `staffJuhuDays`, `requiredNights`도 함께 유실되고 있었다.

## 근본 원인

`useLocalStorage`는 복원 시 저장본을 기본 스키마(`getDefaultSchedule()` 등 `initialValue`)에 deep-merge한다. 기존 `deepMerge`는 **`target`(기본값)의 키만 순회**해서, 저장본에만 있는 키를 결과에서 누락시켰다.

- `cellExclusions`/`requiredNights`는 **동적 키 Record** → 키가 정적 기본 스키마에 절대 존재하지 않음 → 매 새로고침마다 드롭 후 재저장되어 **영구 유실**
- 기본값에 `cellExclusions: {}`를 추가하는 것으로는 못 고침: deep-merge가 한 단계 안쪽에서 동일하게 동적 키를 다시 솎아냄
- `isLocked`는 `assignments` 배열 원소 내부 필드라 배열 통째 교체 경로를 타서 기존에도 정상 보존됨 (이 버그의 영향 없음)

## 변경

`deepMerge`가 **`target`/`source` 키의 합집합**을 순회하도록 변경. 저장본 전용 키는 모든 중첩 단계에서 보존된다.

레거시 필드 제거(`juhuDay` 등)는 버전 기반 `migrateStorageIfNeeded`(version-gated clear)가 담당하므로, source-only 키 보존이 제거된 필드를 되살리지 않는다 → 회귀 없음.

## 검증

- ✅ 복원 동작 회귀 테스트 6개 신규 (동적 Record 키 보존 케이스 포함)
- ✅ 전체 114 테스트 통과 / `tsc --noEmit` / eslint 통과
- ✅ 로컬 앱 CDP 재현: 수정 후 새로고침해도 `cellExclusions`·`staffJuhuDays` 값 보존 확인 (수정 전엔 드롭)

## 영향받는 localStorage 소비자

| 키 | 타입 | 영향 |
|----|------|------|
| `shift-schedule-current` | `Schedule` | `cellExclusions`/`staffJuhuDays` 복원 (수정 대상) |
| `requiredNights` | `Record<string, number>` | 동일 버그 클래스, 함께 해결 |
| `staff`/`previous` | 배열 | 배열 분기라 무관 |
| `config` | 중첩 객체 | 레거시 키는 migration이 먼저 삭제 → 동작 동일 |
