### PR TITLE
feat: surface INFEASIBLE diagnosis in feasibility UI

### DIFF
--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -10,7 +10,8 @@ Start both frontend (Vite) and backend (Chalice) servers for local testing.
 
 1. Start the **backend server** in background:
    - Directory: `../api`
-   - Command: `source .venv/bin/activate && chalice local`
+   - Command: `source .venv/bin/activate && CHALICE_LOCAL=1 chalice local`
+   - `CHALICE_LOCAL=1` makes shift-schedule routes allow any origin (CORS), so localhost:5173 isn't blocked
    - Run in background with `run_in_background: true`
 
 2. Start the **frontend server** in background:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ function ScheduleApp() {
     scheduleCompleteness,
     generationStatus,
     preCheckResult,
+    generateDiagnosis,
     editingCell,
     affectedCells,
     showAllViolations,
@@ -333,7 +334,7 @@ function ScheduleApp() {
           {/* Feasibility result - always visible */}
           <section aria-label="타당성 검사 결과" className="mt-6 space-y-4">
             <ErrorBoundary>
-              <FeasibilityResult result={feasibilityResult} completeness={scheduleCompleteness} preCheckResult={preCheckResult} />
+              <FeasibilityResult result={feasibilityResult} completeness={scheduleCompleteness} preCheckResult={preCheckResult} generateDiagnosis={generateDiagnosis} />
               {feasibilityResult && feasibilityResult.violations.length > 0 && (
                 <ViolationList
                   violations={feasibilityResult.violations}

--- a/src/components/FeasibilityResult.tsx
+++ b/src/components/FeasibilityResult.tsx
@@ -94,7 +94,7 @@ export function FeasibilityResult({ result, completeness = 0, preCheckResult, ge
     <div
       className={cn(
         'p-6 rounded-xl border-2 shadow-sm transition-all duration-300',
-        result.feasible
+        result.feasible && !hasDiagnosis
           ? 'bg-emerald-50 border-emerald-200'
           : 'bg-red-50 border-red-200'
       )}
@@ -104,7 +104,26 @@ export function FeasibilityResult({ result, completeness = 0, preCheckResult, ge
     >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          {result.feasible ? (
+          {hasDiagnosis ? (
+            <>
+              <span
+                className="flex items-center justify-center w-12 h-12 rounded-full bg-red-100"
+                aria-hidden="true"
+              >
+                <svg className="w-7 h-7 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </span>
+              <div>
+                <span className="block text-2xl font-bold text-red-700">
+                  생성 불가
+                </span>
+                <span className="text-sm text-red-600">
+                  솔버가 완성 가능한 근무표를 찾지 못했습니다
+                </span>
+              </div>
+            </>
+          ) : result.feasible ? (
             <>
               <span
                 className="flex items-center justify-center w-12 h-12 rounded-full bg-emerald-100"
@@ -171,6 +190,12 @@ export function FeasibilityResult({ result, completeness = 0, preCheckResult, ge
           )}
         </div>
       </div>
+
+      {hasDiagnosis && (
+        <p className="mt-3 text-xs text-gray-500">
+          위 배지는 입력표(수동 입력) 검사 결과이며, 자동 생성 가능 여부와는 별개입니다.
+        </p>
+      )}
 
       {/* Pre-check analysis detail */}
       {preCheckResult && !preCheckResult.feasible && preCheckResult.reasons.length > 0 && (

--- a/src/components/FeasibilityResult.tsx
+++ b/src/components/FeasibilityResult.tsx
@@ -1,4 +1,4 @@
-import type { FeasibilityResult as FeasibilityResultType, FeasibilityCheckResponse } from '@/types';
+import type { FeasibilityResult as FeasibilityResultType, FeasibilityCheckResponse, InfeasibilityDiagnosis } from '@/types';
 import { cn } from '@/lib/utils';
 
 interface FeasibilityResultProps {
@@ -7,13 +7,20 @@ interface FeasibilityResultProps {
   completeness?: number;
   /** Pre-check result from backend API */
   preCheckResult?: FeasibilityCheckResponse | null;
+  /** UNSAT-core diagnosis from a /generate INFEASIBLE response (solver-only conflicts) */
+  generateDiagnosis?: InfeasibilityDiagnosis | null;
 }
 
 const COMPLETENESS_THRESHOLD = 0.5;
 
-export function FeasibilityResult({ result, completeness = 0, preCheckResult }: FeasibilityResultProps) {
+export function FeasibilityResult({ result, completeness = 0, preCheckResult, generateDiagnosis }: FeasibilityResultProps) {
+  const hasDiagnosis =
+    !!generateDiagnosis &&
+    (generateDiagnosis.conflictingInputs.length > 0 || generateDiagnosis.conflictingConstraints.length > 0);
+
   // Show progress state when schedule is below threshold
-  if (result && completeness < COMPLETENESS_THRESHOLD) {
+  // (but fall through to surface a solver diagnosis even on a sparse grid)
+  if (result && completeness < COMPLETENESS_THRESHOLD && !hasDiagnosis) {
     const percentage = Math.round(completeness * 100);
     return (
       <div
@@ -183,6 +190,33 @@ export function FeasibilityResult({ result, completeness = 0, preCheckResult }: 
               <span>필요: {preCheckResult.analysis.totalRequired} person-days</span>
               <span>가용: {preCheckResult.analysis.totalAvailable} person-days</span>
               <span>주당 OFF: {preCheckResult.analysis.offDaysRequired}일</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Solver UNSAT-core diagnosis: conflicts only the solver can detect */}
+      {hasDiagnosis && generateDiagnosis && (
+        <div className="mt-4 pt-4 border-t border-red-200">
+          <p className="text-sm font-semibold text-red-700 mb-2">생성 실패 원인 (솔버 진단)</p>
+          {generateDiagnosis.conflictingInputs.length > 0 && (
+            <div className="mb-2">
+              <p className="text-xs font-medium text-red-600 mb-1">충돌하는 입력</p>
+              <ul className="list-disc list-inside text-sm text-red-800 space-y-0.5">
+                {generateDiagnosis.conflictingInputs.map((item, i) => (
+                  <li key={`in-${i}`}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {generateDiagnosis.conflictingConstraints.length > 0 && (
+            <div>
+              <p className="text-xs font-medium text-red-600 mb-1">충돌하는 제약</p>
+              <ul className="list-disc list-inside text-sm text-red-800 space-y-0.5">
+                {generateDiagnosis.conflictingConstraints.map((item, i) => (
+                  <li key={`ct-${i}`}>{item}</li>
+                ))}
+              </ul>
             </div>
           )}
         </div>

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -9,6 +9,7 @@ import type {
   FeasibilityResult,
   GenerationStatus,
   FeasibilityCheckResponse,
+  InfeasibilityDiagnosis,
 } from '@/types';
 import { GenerationLimitError } from '@/types/auth';
 import { checkFeasibility, getDefaultConfig } from '@/solver/feasibilityChecker';
@@ -189,6 +190,9 @@ export function useSchedule() {
 
   // Pre-check result for displaying analysis
   const [preCheckResult, setPreCheckResult] = useState<FeasibilityCheckResponse | null>(null);
+
+  // UNSAT-core diagnosis from a /generate INFEASIBLE response (solver-only conflicts)
+  const [generateDiagnosis, setGenerateDiagnosis] = useState<InfeasibilityDiagnosis | null>(null);
 
   // Show all soft violations (triggered by auto-generation or user toggle)
   const [showAllViolations, setShowAllViolations] = useState(false);
@@ -521,6 +525,7 @@ export function useSchedule() {
     };
 
     try {
+      setGenerateDiagnosis(null); // Clear stale diagnosis from a prior attempt
       // Pre-check feasibility before generation
       const checkResult = await checkFeasibilityApi(requestPayload);
       setPreCheckResult(checkResult);
@@ -574,6 +579,7 @@ export function useSchedule() {
         setGenerationStatus('success');
         setShowAllViolations(true);
         setPreCheckResult(null); // Clear pre-check result on success
+        setGenerateDiagnosis(null);
         const lockedCount = lockedAssignments.length;
         const message = lockedCount > 0
           ? `근무표가 자동 생성되었습니다. (고정: ${lockedCount}개)`
@@ -581,6 +587,7 @@ export function useSchedule() {
         toast.success(message);
       } else {
         setGenerationStatus('error');
+        setGenerateDiagnosis(response.error?.diagnosis ?? null);
         const errorMessage = response.error?.message ?? '알 수 없는 오류가 발생했습니다.';
         toast.error(`생성 실패: ${errorMessage}`);
       }
@@ -644,6 +651,7 @@ export function useSchedule() {
     scheduleCompleteness,
     generationStatus,
     preCheckResult,
+    generateDiagnosis,
     editingCell,
     hoveredCell,
     affectedCells,

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -3,9 +3,17 @@ import type { EligibleShift } from './staff';
 
 export type GenerationStatus = 'idle' | 'loading' | 'success' | 'error';
 
+/** UNSAT-core diagnosis attached to an INFEASIBLE error (Korean label strings) */
+export interface InfeasibilityDiagnosis {
+  conflictingConstraints: string[];
+  conflictingInputs: string[];
+}
+
 export interface ApiError {
   code: 'INFEASIBLE' | 'TIMEOUT' | 'INVALID_INPUT';
   message: string;
+  /** Present when the solver could pinpoint conflicting inputs/constraints */
+  diagnosis?: InfeasibilityDiagnosis;
 }
 
 /** Constraint severity configuration for API requests */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export type {
 export type {
   GenerationStatus,
   ApiError,
+  InfeasibilityDiagnosis,
   GenerateRequest,
   GenerateResponse,
   FeasibilityCheckResponse,


### PR DESCRIPTION
## What

Surfaces the backend's new **INFEASIBLE diagnosis** in the feasibility UI: when auto-generation fails because no valid schedule exists, the user now sees *which inputs / constraints conflict* instead of a transient toast.

Pairs with the backend PR (`jongwony/api` → `refactor/extract-build-model`).

## Commits

1. `feat(ui): surface UNSAT-core diagnosis on /generate INFEASIBLE` — adds the `InfeasibilityDiagnosis` type, captures `error.diagnosis` into `generateDiagnosis` state (cleared on generation start / success), and renders a persistent conflict panel (conflicting inputs + constraints) in `FeasibilityResult`.
2. `fix(ui): solver INFEASIBLE owns top-level status, demote local check` — previously a sparse grid showed a green **POSSIBLE** header (from the local grid checker) above the red solver-conflict panel. Root cause: the widget conflated *local-grid validity* with *solver schedulability*. Now a solver INFEASIBLE owns the top-level "생성 불가" status, and the local-check badges are explicitly labeled as input-grid validation (distinct from auto-generation feasibility).

## Behavior

- Diagnosis only appears when the backend returns `error.diagnosis`; absent → unchanged behavior (graceful, key is optional).
- The INFEASIBLE toast is retained alongside the persistent panel.

## Verification

`tsc --noEmit` clean. (Two pre-existing lint errors in untouched files — `AuthContext.tsx`, `solverApi.ts` — are out of scope.)

## Review

Direction confirmed by a 5-angle code review + Codex gpt-5.5 root-cause consult (the UI feasibility-notion contract fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
