### PR TITLE
feat(config): 주휴(juhu) 전역 토글 — 포함/제외 선택

### DIFF
--- a/src/components/ConfigPanel.tsx
+++ b/src/components/ConfigPanel.tsx
@@ -12,7 +12,11 @@ interface ConfigPanelProps {
 
 type ConstraintKey = keyof ConstraintConfig['enabledConstraints'];
 
-const CONSTRAINT_LABELS: Record<ConstraintKey, string> = {
+// Constraints shown in the hard/soft severity group. `juhu` is excluded: it is
+// a standalone global toggle without a severity concept (rendered separately).
+type SeverityConstraintKey = Exclude<ConstraintKey, 'juhu'>;
+
+const CONSTRAINT_LABELS: Record<SeverityConstraintKey, string> = {
   shiftOrder: '역순 금지 (D-E-N 순서)',
   nightOffDay: 'N-OFF-D 금지',
   consecutiveNight: '연속 나이트 제한',
@@ -35,7 +39,7 @@ export function ConfigPanel({ config, onConfigChange }: ConfigPanelProps) {
     });
   };
 
-  const toggleSeverity = (key: ConstraintKey) => {
+  const toggleSeverity = (key: SeverityConstraintKey) => {
     const currentSeverity = config.constraintSeverity?.[key] ?? 'hard';
     const newSeverity: ConstraintSeverity = currentSeverity === 'hard' ? 'soft' : 'hard';
     onConfigChange({
@@ -189,7 +193,7 @@ export function ConfigPanel({ config, onConfigChange }: ConfigPanelProps) {
         </CardHeader>
         <CardContent>
           <div className="space-y-2">
-            {(Object.keys(CONSTRAINT_LABELS) as ConstraintKey[]).map((key) => {
+            {(Object.keys(CONSTRAINT_LABELS) as SeverityConstraintKey[]).map((key) => {
               const isEnabled = config.enabledConstraints[key];
               const severity = config.constraintSeverity?.[key] ?? 'hard';
               const isHard = severity === 'hard';
@@ -231,6 +235,36 @@ export function ConfigPanel({ config, onConfigChange }: ConfigPanelProps) {
                 </div>
               );
             })}
+
+            {/* 주휴: 전역 토글 (Hard/Soft severity 개념 없음) */}
+            <div
+              className={cn(
+                'flex flex-col gap-1 p-2 mt-2 rounded-lg border transition-colors',
+                config.enabledConstraints.juhu
+                  ? 'bg-white border-gray-200'
+                  : 'bg-gray-50 border-gray-100'
+              )}
+            >
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={config.enabledConstraints.juhu}
+                  onChange={() => toggleConstraint('juhu')}
+                  className="h-4 w-4 rounded border-gray-300"
+                />
+                <span
+                  className={cn(
+                    'text-sm',
+                    !config.enabledConstraints.juhu && 'text-gray-400'
+                  )}
+                >
+                  주휴 자동 배정 (주 1회 고정 휴무)
+                </span>
+              </label>
+              <span className="text-[11px] text-muted-foreground pl-6">
+                끄면 주휴를 배정하지 않습니다 (주간 최소 휴무는 유지).
+              </span>
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -520,6 +520,7 @@ export function useSchedule() {
         weeklyStaffing: config.weeklyStaffing,
         constraintSeverity: config.constraintSeverity,
         softConstraints: config.softConstraints,
+        enableJuhu: config.enabledConstraints.juhu,
         requiredNights,
       },
     };

--- a/src/solver/feasibilityChecker.ts
+++ b/src/solver/feasibilityChecker.ts
@@ -158,6 +158,7 @@ export function getDefaultConfig(): ConstraintConfig {
       consecutiveNight: true,
       staffing: true,
       weeklyOff: true,
+      juhu: true,
     },
     constraintSeverity: {
       shiftOrder: 'hard',

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -35,6 +35,13 @@ export interface GenerateRequest {
     constraintSeverity?: ApiConstraintSeverity;
     softConstraints?: SoftConstraintConfig;
     /**
+     * Global toggle for solver-determined weekly holiday (주휴). Default true.
+     * When false, the solver skips juhu assignment entirely (no per-staff
+     * recurring OFF weekday, no distribution objective); the independent
+     * weekly-minimum-OFF requirement is unaffected.
+     */
+    enableJuhu?: boolean;
+    /**
      * Required nights per staff in the window's front portion (= start-month tail).
      * Solver adds hard constraint: sum(N in front portion) == count (when count > 0).
      * Absent or 0 value means unconstrained.
@@ -61,6 +68,8 @@ export interface FeasibilityCheckRequest {
     weeklyWorkHours: number;
     weeklyStaffing: WeeklyStaffing[];
     constraintSeverity?: ApiConstraintSeverity;
+    /** Global toggle for solver-determined weekly holiday (주휴). Default true. */
+    enableJuhu?: boolean;
   };
 }
 

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -86,6 +86,12 @@ export interface ConstraintConfig {
     consecutiveNight: boolean;
     staffing: boolean;
     weeklyOff: boolean;
+    /**
+     * Global toggle for solver-determined weekly holiday (주휴). Backend-only:
+     * sent to the solver as `enableJuhu`. There is no local constraint check
+     * and no hard/soft severity (intentionally absent from constraintSeverity).
+     */
+    juhu: boolean;
   };
   /** User-configurable severity per constraint (hard = error, soft = warning) */
   constraintSeverity: {


### PR DESCRIPTION
## 무엇을

설정에 **주휴(weekly holiday) 전역 토글** 1개를 추가해, 사용자가 주휴를 포함하거나 제외하고 스케줄을 생성할 수 있게 합니다.

- **ON (기본):** 지금처럼 솔버가 직원별 주휴 요일을 자동 결정·강제 OFF·요일 분산.
- **OFF:** 솔버가 주휴 배정을 전체 생략(주간 최소 OFF는 유지). 행 헤더의 요일 표기도 자동으로 사라짐.

## 변경

- **`types/constraint.ts`** — `enabledConstraints.juhu: boolean` 추가. (severity 개념 없음 → `constraintSeverity`에는 의도적으로 미추가)
- **`solver/feasibilityChecker.ts`** — `getDefaultConfig()`에서 `juhu: true`. 기존 사용자는 localStorage deep-merge로 자동 상속 → **스키마 버전 bump 불필요**.
- **`hooks/useSchedule.ts`** — 생성 요청 페이로드의 `constraints`에 `enableJuhu: config.enabledConstraints.juhu` 추가.
- **`types/api.ts`** — `GenerateRequest`·`FeasibilityCheckRequest`에 optional `enableJuhu`.
- **`components/ConfigPanel.tsx`** — "제약조건 설정" 카드에 전용 토글 행("주휴 자동 배정 (주 1회 고정 휴무)") + 보조문구. 다른 하드 제약과 달리 **Hard/Soft 배지 없음**(백엔드가 juhu에 대해 severity를 읽지 않으므로). severity 그룹 키 타입을 `juhu` 제외로 분리.
- **`ScheduleGrid.tsx`** — 변경 없음. `staffJuhuDays`가 비면 이미 이름만 렌더하므로 off 경로 자동 대응.

## 검증

- `npx tsc --noEmit` 통과, `npm test` 61개 통과.
- cdp-attach: 토글 렌더(보조문구·Hard/Soft 배지 부재 확인), ON일 때 요청 페이로드 `enableJuhu: true` 전송, OFF 클릭 시 `localStorage…enabledConstraints.juhu = false` 영속 확인.
- 백엔드 on/off 실동작은 짝 PR의 pytest가 권위(라이브 generate는 솔버가 배포 Lambda 전용이라 로컬 미검증).

## 짝 PR

백엔드(`enableJuhu` 처리): **jongwony/api#12**. 기본 True 하위호환이라 두 PR은 독립 배포 가능.

> 참고: UI 라벨/배치는 기존 패턴 미러링으로 자율 선택했습니다. 문구·위치 조정 의견 환영합니다.
