### PR TITLE
fix(ci): juhu 픽스처 수정 + husky pre-commit 타입체크(재발 방지)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+# Type-check the whole project (incl. tests) before committing.
+# Mirrors the `tsc -b` step of the Pages deploy build, which type-checks
+# test files — catches errors vitest (esbuild, no type-check) misses.
+npm run typecheck

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "husky": "^9.1.7",
         "jsdom": "^27.4.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.19",
@@ -158,7 +159,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -508,7 +508,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -552,7 +551,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2243,7 +2241,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2328,7 +2327,6 @@
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2339,7 +2337,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2350,7 +2347,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2407,7 +2403,6 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -2770,7 +2765,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2821,6 +2815,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3036,7 +3031,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3388,7 +3382,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
@@ -3488,7 +3483,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3986,6 +3980,22 @@
         "node": ">= 14"
       }
     },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4109,7 +4119,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4140,7 +4149,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -4312,6 +4320,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4598,7 +4607,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4643,7 +4651,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4797,6 +4804,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4812,6 +4820,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4854,7 +4863,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4864,7 +4872,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4877,7 +4884,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -5307,7 +5315,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -5515,7 +5522,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5664,7 +5670,6 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5967,7 +5972,6 @@
       "integrity": "sha512-Zw/uYiiyF6pUT1qmKbZziChgNPRu+ZRneAsMUDU6IwmXdWt5JwcUfy2bvLOCUtz5UniaN/Zx5aFttZYbYc7O/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck": "tsc -b",
+    "prepare": "husky"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
@@ -41,6 +43,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "husky": "^9.1.7",
     "jsdom": "^27.4.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.19",

--- a/src/constraints/__tests__/consecutiveNight.test.ts
+++ b/src/constraints/__tests__/consecutiveNight.test.ts
@@ -43,6 +43,7 @@ function createTestContext(
       consecutiveNight: true,
       staffing: true,
       weeklyOff: true,
+      juhu: true,
     },
     constraintSeverity: {
       shiftOrder: 'hard',

--- a/src/constraints/__tests__/maxConsecutiveOff.test.ts
+++ b/src/constraints/__tests__/maxConsecutiveOff.test.ts
@@ -44,6 +44,7 @@ function createTestContext(
       consecutiveNight: true,
       staffing: true,
       weeklyOff: true,
+      juhu: true,
     },
     constraintSeverity: {
       shiftOrder: 'hard',

--- a/src/constraints/__tests__/maxConsecutiveWork.test.ts
+++ b/src/constraints/__tests__/maxConsecutiveWork.test.ts
@@ -44,6 +44,7 @@ function createTestContext(
       consecutiveNight: true,
       staffing: true,
       weeklyOff: true,
+      juhu: true,
     },
     constraintSeverity: {
       shiftOrder: 'hard',

--- a/src/constraints/__tests__/maxPeriodOff.test.ts
+++ b/src/constraints/__tests__/maxPeriodOff.test.ts
@@ -43,6 +43,7 @@ function createTestContext(
       consecutiveNight: true,
       staffing: true,
       weeklyOff: true,
+      juhu: true,
     },
     constraintSeverity: {
       shiftOrder: 'hard',

--- a/src/constraints/__tests__/nightOffDay.test.ts
+++ b/src/constraints/__tests__/nightOffDay.test.ts
@@ -42,6 +42,7 @@ function createTestContext(
       consecutiveNight: true,
       staffing: true,
       weeklyOff: true,
+      juhu: true,
     },
     constraintSeverity: {
       shiftOrder: 'hard',

--- a/src/constraints/__tests__/shiftOrder.test.ts
+++ b/src/constraints/__tests__/shiftOrder.test.ts
@@ -42,6 +42,7 @@ function createTestContext(
       consecutiveNight: true,
       staffing: true,
       weeklyOff: true,
+      juhu: true,
     },
     constraintSeverity: {
       shiftOrder: 'hard',

--- a/src/constraints/__tests__/staffing.test.ts
+++ b/src/constraints/__tests__/staffing.test.ts
@@ -47,6 +47,7 @@ function createTestContext(
       consecutiveNight: true,
       staffing: true,
       weeklyOff: true,
+      juhu: true,
     },
     constraintSeverity: {
       shiftOrder: 'hard',

--- a/src/constraints/__tests__/weeklyOff.test.ts
+++ b/src/constraints/__tests__/weeklyOff.test.ts
@@ -43,6 +43,7 @@ function createTestContext(
       consecutiveNight: true,
       staffing: true,
       weeklyOff: true,
+      juhu: true,
     },
     constraintSeverity: {
       shiftOrder: 'hard',


### PR DESCRIPTION
머지 커밋 `c683d23`의 **GitHub Pages 배포 실패 복구 + 재발 방지**.

## 1) 배포 실패 원인 / 수정
주휴 토글(#15)이 `juhu`를 `enabledConstraints`의 **필수 필드**로 추가했는데, 제약 테스트 픽스처 8곳이 `juhu` 없이 객체 리터럴을 구성했습니다.

- vitest(esbuild, 타입체크 안 함)는 통과 → 로컬·CI 테스트에서 못 잡음.
- 배포 빌드 `tsc -b`는 **테스트 파일까지 타입체크** → `TS2741` 8건으로 빌드 실패 → 배포 차단.

**수정**: 8개 픽스처(`consecutiveNight, maxConsecutiveOff, maxConsecutiveWork, maxPeriodOff, nightOffDay, shiftOrder, staffing, weeklyOff`)의 `enabledConstraints`에 `juhu: true` 추가. 타입은 다른 5개 필드와 동일하게 필수 유지.

## 2) 재발 방지 — husky pre-commit (`tsc -b`)
같은 클래스의 에러를 커밋 단계에서 잡도록 husky pre-commit 훅 추가:
- `typecheck` 스크립트 = `tsc -b` (배포 빌드의 타입체크 단계와 동일, 테스트 파일 포함)
- `.husky/pre-commit` → `npm run typecheck`
- husky devDependency + `prepare: husky` (clone 후 `npm install` 시 자동 활성)

> 두 변경을 한 PR로 묶은 이유: husky 훅이 `tsc -b`를 돌리므로, 픽스처 수정이 없으면 훅 도입 커밋 자체가 기존 에러로 막힙니다(의존 관계).

## 검증
- `npm run build` (`tsc -b && vite build`) 통과 — CI와 동일 명령.
- `npm test` 61개 통과.
- pre-commit 훅: 정상 상태 통과(exit 0), 픽스처에서 juhu 제거 시 TS2741로 차단(exit 2) 확인.

머지되면 Pages 배포 재개 → 주휴 토글 UI 라이브.
