### PR TITLE
feat: add day shift fairness soft constraint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,8 +227,9 @@ source .venv/bin/activate && chalice local
   2. Add type to `SoftConstraintConfig` in `src/types/constraint.ts`
   3. Add default in `getDefaultConfig()` under `softConstraints`
   4. Register in `src/constraints/index.ts`
-  5. Backend: Create `../api/chalicelib/soft_constraints/{snake_case}.py` implementing `SoftConstraint` protocol
-  6. Register in `soft_constraints/__init__.py`
+  5. Register UI toggle in `src/components/SoftConstraintSettings.tsx` (add a `ConstraintInfo` entry to `WORKER_CONSTRAINTS` or `MANAGER_CONSTRAINTS` with matching `id`/`tier`) — the settings list is hardcoded, so without this the constraint runs (default-enabled) but has no user-facing toggle
+  6. Backend: Create `../api/chalicelib/soft_constraints/{snake_case}.py` implementing `SoftConstraint` protocol
+  7. Register in `soft_constraints/__init__.py`
 - When adding **boundary-aware** soft constraint (considers previous period):
   1. Frontend: Use Map-based lookup with `_count_trailing_*` or similar helper
   2. Backend: Extract `previous_period_end` from context, build `shift_by_date` Map

--- a/src/components/SoftConstraintSettings.tsx
+++ b/src/components/SoftConstraintSettings.tsx
@@ -89,6 +89,13 @@ const WORKER_CONSTRAINTS: ConstraintInfo[] = [
     perspective: 'worker',
   },
   {
+    id: 'dayShiftFairness',
+    name: '데이공정성',
+    description: '데이 근무 공정 분배',
+    tier: 3,
+    perspective: 'worker',
+  },
+  {
     id: 'shiftContinuity',
     name: '근무연속성',
     description: '동일 근무 연속 유지',

--- a/src/constraints/__tests__/consecutiveNight.test.ts
+++ b/src/constraints/__tests__/consecutiveNight.test.ts
@@ -62,6 +62,7 @@ function createTestContext(
       restClustering: { enabled: true },
       postRestDayShift: { enabled: true },
       weekendFairness: { enabled: true },
+      dayShiftFairness: { enabled: true },
       shiftContinuity: { enabled: true },
     },
   };

--- a/src/constraints/__tests__/dayShiftFairness.test.ts
+++ b/src/constraints/__tests__/dayShiftFairness.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from 'vitest';
+import { dayShiftFairnessConstraint } from '../dayShiftFairness';
+import type { ConstraintContext } from '../types';
+import type { Schedule, Staff, ConstraintConfig, ShiftAssignment } from '@/types';
+
+function createTestContext(
+  assignments: ShiftAssignment[],
+  staffList?: Staff[],
+  enabled: boolean = true
+): ConstraintContext {
+  const schedule: Schedule = {
+    id: 'test-schedule',
+    name: 'Test Schedule',
+    startDate: '2025-01-06', // Monday
+    assignments,
+  };
+
+  const staff: Staff[] = staffList ?? [
+    { id: 'staff-1', name: '연혜경' },
+    { id: 'staff-2', name: '김지원' },
+  ];
+
+  const config: ConstraintConfig = {
+    maxConsecutiveNights: 4,
+    weeklyWorkHours: 40,
+    weeklyStaffing: Array.from({ length: 4 }, () => ({
+      weekday: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+      friday: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+      weekend: {
+        day: { min: 1, max: 2 },
+        evening: { min: 1, max: 2 },
+        night: { min: 1, max: 2 },
+      },
+    })),
+    enabledConstraints: {
+      shiftOrder: true,
+      nightOffDay: true,
+      consecutiveNight: true,
+      staffing: true,
+      weeklyOff: true,
+      juhu: true,
+    },
+    constraintSeverity: {
+      shiftOrder: 'hard',
+      nightOffDay: 'hard',
+      consecutiveNight: 'hard',
+      staffing: 'hard',
+      weeklyOff: 'hard',
+    },
+    softConstraints: {
+      maxConsecutiveWork: { enabled: true, maxDays: 5 },
+      nightBlockPolicy: { enabled: true, minBlockSize: 2 },
+      maxPeriodOff: { enabled: true, maxOff: 9 },
+      maxConsecutiveOff: { enabled: true, maxDays: 2 },
+      gradualShiftProgression: { enabled: true },
+      maxSameShiftConsecutive: { enabled: true },
+      restClustering: { enabled: true },
+      postRestDayShift: { enabled: true },
+      weekendFairness: { enabled: true },
+      dayShiftFairness: { enabled },
+      shiftContinuity: { enabled: true },
+    },
+  };
+
+  return { schedule, staff, config, previousPeriodEnd: [], scheduleCompleteness: 1 };
+}
+
+// Helper: build N day-shift assignments for a staff starting at the period start
+function buildDayShifts(staffId: string, count: number): ShiftAssignment[] {
+  const dates = [
+    '2025-01-06', '2025-01-07', '2025-01-08', '2025-01-09', '2025-01-10',
+    '2025-01-11', '2025-01-12', '2025-01-13', '2025-01-14', '2025-01-15',
+    '2025-01-16', '2025-01-17', '2025-01-18', '2025-01-19', '2025-01-20',
+  ];
+  return dates.slice(0, count).map((date) => ({ staffId, date, shift: 'D' as const }));
+}
+
+describe('dayShiftFairnessConstraint', () => {
+  it('should pass when day shift distribution is balanced', () => {
+    // Both staff have the same number of D shifts (4 each)
+    const assignments: ShiftAssignment[] = [
+      ...buildDayShifts('staff-1', 4),
+      ...buildDayShifts('staff-2', 4),
+    ];
+
+    const context = createTestContext(assignments);
+    const result = dayShiftFairnessConstraint.check(context);
+
+    expect(result.satisfied).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('should detect when one staff has many more day shifts than others', () => {
+    // staff-1 has 10 D shifts, staff-2 has 0 → average 5, deviation 5 > 2
+    const assignments: ShiftAssignment[] = [
+      ...buildDayShifts('staff-1', 10),
+    ];
+
+    const context = createTestContext(assignments);
+    const result = dayShiftFairnessConstraint.check(context);
+
+    expect(result.satisfied).toBe(false);
+    expect(result.violations.length).toBeGreaterThan(0);
+    expect(result.violations[0].constraintId).toBe('day-shift-fairness');
+    expect(result.violations[0].context?.staffId).toBe('staff-1');
+  });
+
+  it('should not run when disabled', () => {
+    const assignments: ShiftAssignment[] = [
+      ...buildDayShifts('staff-1', 10),
+    ];
+
+    const context = createTestContext(assignments, undefined, false);
+    const result = dayShiftFairnessConstraint.check(context);
+
+    expect(result.satisfied).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('should only count D shifts, not E/N', () => {
+    // staff-1 works many E/N but few D; staff-2 also few D → no D fairness violation
+    const eveningNights: ShiftAssignment[] = [
+      { staffId: 'staff-1', date: '2025-01-06', shift: 'E' },
+      { staffId: 'staff-1', date: '2025-01-07', shift: 'N' },
+      { staffId: 'staff-1', date: '2025-01-08', shift: 'E' },
+      { staffId: 'staff-1', date: '2025-01-09', shift: 'N' },
+      { staffId: 'staff-1', date: '2025-01-10', shift: 'D' },
+      { staffId: 'staff-2', date: '2025-01-06', shift: 'D' },
+    ];
+
+    const context = createTestContext(eveningNights);
+    const result = dayShiftFairnessConstraint.check(context);
+
+    // staff-1: 1 D, staff-2: 1 D → balanced, no violation despite heavy E/N load
+    expect(result.satisfied).toBe(true);
+    expect(result.violations).toHaveLength(0);
+  });
+});

--- a/src/constraints/__tests__/maxConsecutiveOff.test.ts
+++ b/src/constraints/__tests__/maxConsecutiveOff.test.ts
@@ -63,6 +63,7 @@ function createTestContext(
       restClustering: { enabled: true },
       postRestDayShift: { enabled: true },
       weekendFairness: { enabled: true },
+      dayShiftFairness: { enabled: true },
       shiftContinuity: { enabled: true },
     },
   };

--- a/src/constraints/__tests__/maxConsecutiveWork.test.ts
+++ b/src/constraints/__tests__/maxConsecutiveWork.test.ts
@@ -63,6 +63,7 @@ function createTestContext(
       restClustering: { enabled: true },
       postRestDayShift: { enabled: true },
       weekendFairness: { enabled: true },
+      dayShiftFairness: { enabled: true },
       shiftContinuity: { enabled: true },
     },
   };

--- a/src/constraints/__tests__/maxPeriodOff.test.ts
+++ b/src/constraints/__tests__/maxPeriodOff.test.ts
@@ -62,6 +62,7 @@ function createTestContext(
       restClustering: { enabled: true },
       postRestDayShift: { enabled: true },
       weekendFairness: { enabled: true },
+      dayShiftFairness: { enabled: true },
       shiftContinuity: { enabled: true },
     },
   };

--- a/src/constraints/__tests__/nightOffDay.test.ts
+++ b/src/constraints/__tests__/nightOffDay.test.ts
@@ -61,6 +61,7 @@ function createTestContext(
       restClustering: { enabled: true },
       postRestDayShift: { enabled: true },
       weekendFairness: { enabled: true },
+      dayShiftFairness: { enabled: true },
       shiftContinuity: { enabled: true },
     },
   };

--- a/src/constraints/__tests__/shiftOrder.test.ts
+++ b/src/constraints/__tests__/shiftOrder.test.ts
@@ -61,6 +61,7 @@ function createTestContext(
       restClustering: { enabled: true },
       postRestDayShift: { enabled: true },
       weekendFairness: { enabled: true },
+      dayShiftFairness: { enabled: true },
       shiftContinuity: { enabled: true },
     },
   };

--- a/src/constraints/__tests__/staffing.test.ts
+++ b/src/constraints/__tests__/staffing.test.ts
@@ -66,6 +66,7 @@ function createTestContext(
       restClustering: { enabled: true },
       postRestDayShift: { enabled: true },
       weekendFairness: { enabled: true },
+      dayShiftFairness: { enabled: true },
       shiftContinuity: { enabled: true },
     },
   };

--- a/src/constraints/__tests__/weeklyOff.test.ts
+++ b/src/constraints/__tests__/weeklyOff.test.ts
@@ -62,6 +62,7 @@ function createTestContext(
       restClustering: { enabled: true },
       postRestDayShift: { enabled: true },
       weekendFairness: { enabled: true },
+      dayShiftFairness: { enabled: true },
       shiftContinuity: { enabled: true },
     },
   };

--- a/src/constraints/dayShiftFairness.ts
+++ b/src/constraints/dayShiftFairness.ts
@@ -1,0 +1,91 @@
+import { parseISO, addDays, format } from 'date-fns';
+import type { Violation, ShiftAssignment } from '@/types';
+import type { Constraint, ConstraintContext } from './types';
+
+function getShiftForStaffOnDate(
+  assignments: ShiftAssignment[],
+  staffId: string,
+  date: string
+): string | null {
+  const assignment = assignments.find(
+    (a) => a.staffId === staffId && a.date === date
+  );
+  return assignment?.shift ?? null;
+}
+
+export const dayShiftFairnessConstraint: Constraint = {
+  id: 'day-shift-fairness',
+  name: '데이공정성',
+  description: '데이 근무 분배 공정성 확인',
+  severityType: 'soft',
+
+  check(context: ConstraintContext) {
+    const { schedule, staff, config } = context;
+    const violations: Violation[] = [];
+
+    const softConfig = config.softConstraints?.dayShiftFairness;
+    if (!softConfig?.enabled) {
+      return { satisfied: true, violations: [] };
+    }
+
+    const startDate = parseISO(schedule.startDate);
+    const periodDays = 28;
+
+    // Count day (D) shifts for each staff member
+    const dayShiftCounts: Map<string, number> = new Map();
+
+    for (const staffMember of staff) {
+      let dayShifts = 0;
+
+      for (let i = 0; i < periodDays; i++) {
+        const currentDate = addDays(startDate, i);
+        const currentDateStr = format(currentDate, 'yyyy-MM-dd');
+
+        const shift = getShiftForStaffOnDate(
+          schedule.assignments,
+          staffMember.id,
+          currentDateStr
+        );
+
+        if (shift === 'D') {
+          dayShifts++;
+        }
+      }
+
+      dayShiftCounts.set(staffMember.id, dayShifts);
+    }
+
+    // Calculate average and check for significant deviation
+    const counts = Array.from(dayShiftCounts.values());
+    if (counts.length === 0) {
+      return { satisfied: true, violations: [] };
+    }
+
+    const average = counts.reduce((a, b) => a + b, 0) / counts.length;
+    const threshold = 2; // Deviation threshold
+
+    for (const staffMember of staff) {
+      const count = dayShiftCounts.get(staffMember.id) ?? 0;
+      const deviation = count - average;
+
+      // Only flag if significantly above average (working too many day shifts)
+      if (deviation > threshold) {
+        violations.push({
+          constraintId: 'day-shift-fairness',
+          constraintName: '데이공정성',
+          severity: 'warning',
+          message: `${staffMember.name}: 데이 근무 ${count}일 (평균 ${average.toFixed(1)}일 대비 ${deviation.toFixed(1)}일 초과)`,
+          context: {
+            staffId: staffMember.id,
+            staffName: staffMember.name,
+          },
+        });
+      }
+    }
+
+    return {
+      satisfied: violations.length === 0,
+      violations,
+    };
+  },
+};

--- a/src/constraints/index.ts
+++ b/src/constraints/index.ts
@@ -16,6 +16,7 @@ import { restClusteringConstraint } from './restClustering';
 import { postRestDayShiftConstraint } from './postRestDayShift';
 // Soft constraints - Quality of life
 import { weekendFairnessConstraint } from './weekendFairness';
+import { dayShiftFairnessConstraint } from './dayShiftFairness';
 import { shiftContinuityConstraint } from './shiftContinuity';
 import type { Constraint } from './types';
 
@@ -39,6 +40,7 @@ export const constraintRegistry: Constraint[] = [
   postRestDayShiftConstraint,
   // Soft constraints - Quality of life (T3)
   weekendFairnessConstraint,
+  dayShiftFairnessConstraint,
   shiftContinuityConstraint,
 ];
 
@@ -60,6 +62,7 @@ export { restClusteringConstraint } from './restClustering';
 export { postRestDayShiftConstraint } from './postRestDayShift';
 // Soft constraints - Quality of life
 export { weekendFairnessConstraint } from './weekendFairness';
+export { dayShiftFairnessConstraint } from './dayShiftFairness';
 export { shiftContinuityConstraint } from './shiftContinuity';
 
 export type { Constraint, ConstraintContext, ConstraintResult, ConstraintSeverityType } from './types';

--- a/src/solver/feasibilityChecker.ts
+++ b/src/solver/feasibilityChecker.ts
@@ -181,6 +181,7 @@ export function getDefaultConfig(): ConstraintConfig {
       postRestDayShift: { enabled: true },
       // Tier 3 - Quality of life
       weekendFairness: { enabled: true },
+      dayShiftFairness: { enabled: true },
       shiftContinuity: { enabled: true },
     },
   };

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -73,6 +73,7 @@ export interface SoftConstraintConfig {
   postRestDayShift: SoftConstraintItemConfig;
   // Tier 3 - Quality of life
   weekendFairness: SoftConstraintItemConfig;
+  dayShiftFairness: SoftConstraintItemConfig;
   shiftContinuity: SoftConstraintItemConfig;
 }
 


### PR DESCRIPTION
## Summary
Adds a **day shift fairness** soft constraint that promotes fair distribution of Day (D) shift counts across staff over the 28-day period.

- Soft constraint, **Tier 3, weight 30** — mirrors the existing `weekendFairness` design.
- `check()` flags any staff member whose D count exceeds the staff average by more than 2 (UI display only).
- New config key `dayShiftFairness`, **enabled by default** in `getDefaultConfig()`.
- Registered in the constraint registry (`src/constraints/index.ts`).
- 4 unit tests added for the new constraint.

## Files
- `src/constraints/dayShiftFairness.ts` (new)
- `src/constraints/__tests__/dayShiftFairness.test.ts` (new, 4 tests)
- `src/types/constraint.ts` (added `dayShiftFairness` to `SoftConstraintConfig`)
- `src/solver/feasibilityChecker.ts` (default config entry)
- `src/constraints/index.ts` (registry)
- 8 sibling constraint test files updated to include `dayShiftFairness` in their inline `softConstraints` literals (required by the new type field; behaviorally inert since those tests call `constraint.check()` directly)

## Verification
- `npm run typecheck` (`tsc -b`, also the husky pre-commit hook) — exit 0, clean
- `npm test` (vitest) — 65/65 pass

---
**Backend counterpart:** https://github.com/jongwony/api/pull/13
